### PR TITLE
Properly parse comments from HTML to jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/argparse": "^1.0.35",
     "@types/diff": "^3.5.2",
+    "@types/htmlparser2": "^3.7.31",
     "@types/jasmine": "^3.3.1",
     "@types/node": "^10.12.9",
     "child_process": "^1.0.2",
@@ -35,7 +36,8 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "argparse": "^1.0.10"
+    "argparse": "^1.0.10",
+    "htmlparser2": "^3.10.0"
   },
   "peerDependencies": {
     "typescript": "^3.1.6"

--- a/tests/baselines/comments.nt
+++ b/tests/baselines/comments.nt
@@ -2,5 +2,5 @@
 <http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
 <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
-<http://schema.org/name> <http://www.w3.org/2000/01/rdf-schema#comment> "Names are great!" .
-<http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#comment> "Things are amazing!" .
+<http://schema.org/name> <http://www.w3.org/2000/01/rdf-schema#comment> "Names are great!\n <a href=\"X\">Y</a>" .
+<http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#comment> "Things are amazing!\n\n<br/><br /><ul><li>Foo</li><li>Bar</li><li><em>Baz</em>, and <strong>Bat</strong></li><ul>" .

--- a/tests/baselines/comments.ts.txt
+++ b/tests/baselines/comments.ts.txt
@@ -3,7 +3,7 @@
 /** Boolean: True or False. */
 export type Boolean = boolean;
 
-/** A date value in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601 date format</a>. */
+/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
 export type Date = string;
 
 /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
@@ -20,9 +20,15 @@ export type Time = string;
 
 type ThingBase = {
     "@type": "Thing";
-    /** Names are great! */
+    /** Names are great! {@link X Y} */
     "name"?: Text | Text[];
 };
-/** Things are amazing! */
+/**
+ * Things are amazing!
+ *
+ * - Foo
+ * - Bar
+ * - _Baz_, and __Bat__
+ */
 export type Thing = ThingBase;
 

--- a/tests/baselines/inheritance_multiple.ts.txt
+++ b/tests/baselines/inheritance_multiple.ts.txt
@@ -3,7 +3,7 @@
 /** Boolean: True or False. */
 export type Boolean = boolean;
 
-/** A date value in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601 date format</a>. */
+/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
 export type Date = string;
 
 /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */

--- a/tests/baselines/inheritance_one.ts.txt
+++ b/tests/baselines/inheritance_one.ts.txt
@@ -3,7 +3,7 @@
 /** Boolean: True or False. */
 export type Boolean = boolean;
 
-/** A date value in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601 date format</a>. */
+/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
 export type Date = string;
 
 /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */

--- a/tests/baselines/simple.ts.txt
+++ b/tests/baselines/simple.ts.txt
@@ -3,7 +3,7 @@
 /** Boolean: True or False. */
 export type Boolean = boolean;
 
-/** A date value in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601 date format</a>. */
+/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
 export type Date = string;
 
 /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */


### PR DESCRIPTION
Produces a TypeScript output with a nicer format, including:

```ts
/**
 * {@link http://foo.com label}
 * _italic_
 * __bold__
 * - Unordered Lists
 * - Like this.
 * And `preformatted text`.
 * and Newlines!
 */
```

Uses htmlparser2 to output simple jsdoc/Markdown formatted comments.
Strips or unescapes certain control characters, etc.