### PR TITLE
Support Custom Context

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -20,6 +20,7 @@ export interface Options {
   schema: string;
   layer: string;
   deprecated: boolean;
+  context: string;
 }
 export function ParseFlags(): Options|undefined {
   const parser = new ArgumentParser(
@@ -41,6 +42,18 @@ export function ParseFlags(): Options|undefined {
     help: 'Which layer of the schema to load? E.g. schema or all-layers.',
     metavar: 'name_of_file',
     dest: 'layer'
+  });
+  parser.addArgument('--context', {
+    defaultValue: 'https://schema.org',
+    help: 'Single URL or comma-separated key:value pairs defining the ' +
+        'intended \'@context\' for the generated JSON-LD typings. ' +
+        'By default, this is \'https://schema.org\`. Alternatively: ' +
+        '--context=rdf:http://www.w3.org/2000/01/rdf-schema,' +
+        'schema:https://schema.org\n' +
+        'would result in \'rdf:\' being a prefix for any RDF Schema ' +
+        'property, and \'schema:\' being a prefix for any Schema.org property.',
+    metavar: 'key1:url,key2:url,...',
+    dest: 'context'
   });
 
   const deprecated = parser.addMutuallyExclusiveGroup({required: false});

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -19,6 +19,7 @@ import {createPrinter, createSourceFile, EmitHint, NewLineKind, ScriptKind, Scri
 import {asTopicArray} from '../triples/operators';
 import {Triple} from '../triples/triple';
 import {Sort} from '../ts/class';
+import {Context} from '../ts/context';
 
 import {ProcessClasses} from './toClass';
 import {ProcessEnums} from './toEnum';
@@ -40,6 +41,7 @@ import {ProcessProperties,} from './toProperty';
 export async function WriteDeclarations(
     triples: Observable<Triple>,
     includeDeprecated: boolean,
+    context: Context,
     write: (content: string) => Promise<void>| void,
 ) {
   const topics = await triples.pipe(asTopicArray()).toPromise();
@@ -55,10 +57,13 @@ export async function WriteDeclarations(
       ScriptKind.TS);
   const printer = createPrinter({newLine: NewLineKind.LineFeed});
 
+  write(printer.printNode(EmitHint.Unspecified, context.toNode(), source));
+  write('\n\n');
+
   for (const cls of sorted) {
     if (cls.deprecated && !includeDeprecated) continue;
 
-    for (const node of cls.toNode(!includeDeprecated)) {
+    for (const node of cls.toNode(context, !includeDeprecated)) {
       const result = printer.printNode(EmitHint.Unspecified, node, source);
       await write(result);
       await write('\n');

--- a/src/ts/context.ts
+++ b/src/ts/context.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createIntersectionTypeNode, createLiteralTypeNode, createModifiersFromModifierFlags, createPropertySignature, createStringLiteral, createTypeAliasDeclaration, createTypeLiteralNode, createTypeParameterDeclaration, createTypeReferenceNode, ModifierFlags} from 'typescript';
+
+import {TSubject} from '../triples/triple';
+
+import {withComments} from './util/comments';
+
+export class Context {
+  private readonly context: Array<[string, string]> = [];
+
+  setUrlContext(ctx: string) {
+    if (this.context.length > 0) {
+      throw new Error(
+          'Attempting to set a default URL context, ' +
+          'but other named contexts exist already.');
+    }
+    this.context.push(['', ctx]);
+  }
+  addNamedContext(name: string, url: string) {
+    this.context.push([name, url]);
+  }
+  validate() {
+    if (this.context.length === 0) throw new Error('Invalid empty context.');
+    if (this.context.length === 1) return;  // One context is always right.
+
+    // Make sure no key is duplicated.
+    const seen: Set<string> = new Set<string>();
+    for (const [name] of this.context) {
+      if (seen.has(name)) {
+        throw new Error(`Named context ${name} found twice in context.`);
+      }
+      if (name === '') {
+        throw new Error(
+            'Context with multipled named contexts includes unnamed URL.');
+      }
+      seen.add(name);
+    }
+  }
+
+  getScopedName(node: TSubject): string {
+    for (const [name, url] of this.context) {
+      if (node.matchesContext(url)) {
+        return name === '' ? node.name : `${name}:${node.name}`;
+      }
+    }
+    return node.toString();
+  }
+
+  private typeNode() {
+    // Either:
+    // "@context": "https://schema.org" or similar:
+    if (this.context.length === 1 && this.context[0][0] === '') {
+      return createLiteralTypeNode(createStringLiteral(this.context[0][1]));
+    }
+
+    // or "@context" is a literal object type of key-values of URLs:
+    return createTypeLiteralNode(
+        /*members=*/this.context.map(
+            ([name, url]) => createPropertySignature(
+                /*modifiers=*/[],
+                createStringLiteral(name),
+                /*questionToken=*/undefined,
+                createLiteralTypeNode(createStringLiteral(url)),
+                /*initializer=*/undefined,
+                )));
+  }
+
+  toNode() {
+    // export type WithContent<T extends Thing> = T & { "@context": TYPE_NODE }
+    return withComments(
+        'Used at the top-level node to indicate the context for the JSON-LD ' +
+            'objects used. The context provided in this type is compatible ' +
+            'with the keys and URLs in the rest of this generated file.',
+        createTypeAliasDeclaration(
+            /*decorators=*/[],
+            createModifiersFromModifierFlags(ModifierFlags.Export),
+            'WithContext',
+            [
+              createTypeParameterDeclaration(
+                  'T', /*constraint=*/
+                  createTypeReferenceNode(
+                      'Thing', /*typeArguments=*/undefined)),
+            ],
+            createIntersectionTypeNode([
+              createTypeReferenceNode('T', /*typeArguments=*/undefined),
+              createTypeLiteralNode([createPropertySignature(
+                  /*modifiers=*/[],
+                  createStringLiteral('@context'),
+                  /*questionToken=*/undefined,
+                  this.typeNode(),
+                  /*initializer=*/undefined,
+                  )]),
+            ])),
+    );
+  }
+}

--- a/src/ts/util/names.ts
+++ b/src/ts/util/names.ts
@@ -32,10 +32,6 @@ export function toTypeName(object: TObject): string {
   }
 }
 
-export function toScopedName(subject: TSubject): string {
-  return subject.name;
-}
-
 export function toEnumName(subject: TSubject): string {
-  return toScopedName(subject).replace(/[^A-Za-z0-9_]/g, '_');
+  return (subject.name).replace(/[^A-Za-z0-9_]/g, '_');
 }

--- a/tests/baseline_test.ts
+++ b/tests/baseline_test.ts
@@ -28,6 +28,7 @@ import {switchMap} from 'rxjs/operators';
 import {WriteDeclarations} from '../src/transform/transform';
 import {process, toTripleStrings} from '../src/triples/reader';
 import {Triple} from '../src/triples/triple';
+import {Context} from '../src/ts/context';
 
 import {addMatchers} from './helpers/baseline';
 
@@ -68,9 +69,12 @@ function getTriples(file: string): Observable<Triple> {
 
 async function getResult(triples: Observable<Triple>) {
   const result: string[] = [];
-  await WriteDeclarations(triples, true, content => {
-    result.push(content);
-  });
+  const context = new Context();
+  context.setUrlContext('https://schema.org');
+  await WriteDeclarations(
+      triples, /*includeDeprecated=*/true, context, content => {
+        result.push(content);
+      });
   return result.join('');
 }
 

--- a/tests/baselines/comments.ts.txt
+++ b/tests/baselines/comments.ts.txt
@@ -1,5 +1,10 @@
 // tslint:disable
 
+/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+
 /** Boolean: True or False. */
 export type Boolean = boolean;
 

--- a/tests/baselines/inheritance_multiple.ts.txt
+++ b/tests/baselines/inheritance_multiple.ts.txt
@@ -1,5 +1,10 @@
 // tslint:disable
 
+/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+
 /** Boolean: True or False. */
 export type Boolean = boolean;
 

--- a/tests/baselines/inheritance_one.ts.txt
+++ b/tests/baselines/inheritance_one.ts.txt
@@ -1,5 +1,10 @@
 // tslint:disable
 
+/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+
 /** Boolean: True or False. */
 export type Boolean = boolean;
 

--- a/tests/baselines/simple.ts.txt
+++ b/tests/baselines/simple.ts.txt
@@ -1,5 +1,10 @@
 // tslint:disable
 
+/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+
 /** Boolean: True or False. */
 export type Boolean = boolean;
 

--- a/tests/ts/context_test.ts
+++ b/tests/ts/context_test.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import 'jasmine';
+
+import {createPrinter, createSourceFile, EmitHint, NewLineKind, Node, ScriptKind, ScriptTarget} from 'typescript';
+
+import {UrlNode} from '../../src/triples/types';
+import {Context} from '../../src/ts/context';
+
+function asString(node: Node): string {
+  const printer = createPrinter({newLine: NewLineKind.LineFeed});
+  const source = createSourceFile(
+      'test.ts', '', ScriptTarget.Latest, /*setParentNodes=*/false,
+      ScriptKind.TS);
+  return printer.printNode(EmitHint.Unspecified, node, source);
+}
+
+describe('WithContext generation', () => {
+  it('with one item', () => {
+    const ctx = new Context();
+    ctx.setUrlContext('https://foo.com');
+
+    expect(asString(ctx.toNode()))
+        .toEqual(
+            `/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://foo.com";
+};`);
+  });
+
+  it('with named items', () => {
+    const ctx = new Context();
+    ctx.addNamedContext('a', 'https://foo.com');
+    ctx.addNamedContext('b', 'https://bar.com');
+
+    expect(asString(ctx.toNode()))
+        .toEqual(
+            `/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": {
+        "a": "https://foo.com";
+        "b": "https://bar.com";
+    };
+};`);
+  });
+});
+
+describe('Context.validate', () => {
+  it('empty throws', () => {
+    expect(() => {
+      const ctx = new Context();
+      ctx.validate();
+    }).toThrowError('Invalid empty context.');
+  });
+
+  it('duplicate throws', () => {
+    expect(() => {
+      const ctx = new Context();
+      ctx.addNamedContext('a', 'foo.com');
+      ctx.addNamedContext('a', 'bar.com');
+      ctx.validate();
+    }).toThrowError('Named context a found twice in context.');
+  });
+
+  it('empty name throws', () => {
+    expect(() => {
+      const ctx = new Context();
+      ctx.addNamedContext('a', 'foo.com');
+      ctx.addNamedContext('', 'bar.com');
+      ctx.validate();
+    })
+        .toThrowError(
+            'Context with multipled named contexts includes unnamed URL.');
+  });
+});
+
+describe('Context.getScopedName', () => {
+  it('with single domain URL (https)', () => {
+    const ctx = new Context();
+    ctx.setUrlContext('https://schema.org');
+
+    expect(ctx.getScopedName(UrlNode.Parse('https://schema.org/Thing')))
+        .toEqual('Thing');
+    expect(ctx.getScopedName(UrlNode.Parse('https://schema.org/rangeIncludes')))
+        .toEqual('rangeIncludes');
+    expect(ctx.getScopedName(UrlNode.Parse('http://schema.org/Door')))
+        .toEqual('Door');
+    expect(ctx.getScopedName(UrlNode.Parse('https://foo.org/Door')))
+        .toEqual('https://foo.org/Door');
+  });
+
+  it('with single domain URL (http)', () => {
+    const ctx = new Context();
+    ctx.setUrlContext('http://schema.org');
+
+    expect(ctx.getScopedName(UrlNode.Parse('http://schema.org/Thing')))
+        .toEqual('Thing');
+    expect(ctx.getScopedName(UrlNode.Parse('http://schema.org/rangeIncludes')))
+        .toEqual('rangeIncludes');
+    expect(ctx.getScopedName(UrlNode.Parse('https://schema.org/Door')))
+        .toEqual('https://schema.org/Door');
+    expect(ctx.getScopedName(UrlNode.Parse('http://foo.org/Door')))
+        .toEqual('http://foo.org/Door');
+  });
+
+  it('with multiple URLs', () => {
+    const ctx = new Context();
+    ctx.addNamedContext('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+    ctx.addNamedContext('rdfs', 'http://www.w3.org/2000/01/rdf-schema#');
+    ctx.addNamedContext('schema', 'http://schema.org/');
+
+    expect(ctx.getScopedName(UrlNode.Parse('http://schema.org/Thing')))
+        .toEqual('schema:Thing');
+    expect(ctx.getScopedName(UrlNode.Parse(
+               'http://www.w3.org/1999/02/22-rdf-syntax-ns#type')))
+        .toEqual('rdf:type');
+    expect(ctx.getScopedName(UrlNode.Parse(
+               'http://www.w3.org/2000/01/rdf-schema#subClassOf')))
+        .toEqual('rdfs:subClassOf');
+    expect(ctx.getScopedName(UrlNode.Parse('http://foo.org/Door')))
+        .toEqual('http://foo.org/Door');
+  });
+});


### PR DESCRIPTION
- `@type` and property names are defined relative to Context.
- Introduce `WithContext<T extends Thing>` to assert the context in a
  source file.

Fixes #3 