### PR TITLE
Fix bug: Having sub-types does not mean you cannot delcare an object …

### DIFF
--- a/tests/baselines/inheritance_multiple.ts.txt
+++ b/tests/baselines/inheritance_multiple.ts.txt
@@ -35,7 +35,9 @@ export type Person = PersonBase;
 type ThingBase = {
     "name"?: Text | Text[];
 };
-export type Thing = (Person | Vehicle);
+export type Thing = ({
+    "@type": "Thing";
+} & ThingBase) | (Person | Vehicle);
 
 type VehicleBase = ThingBase & {
     "@type": "Vehicle";

--- a/tests/baselines/inheritance_one.ts.txt
+++ b/tests/baselines/inheritance_one.ts.txt
@@ -35,5 +35,7 @@ export type Person = PersonBase;
 type ThingBase = {
     "name"?: Text | Text[];
 };
-export type Thing = Person;
+export type Thing = ({
+    "@type": "Thing";
+} & ThingBase) | Person;
 


### PR DESCRIPTION
…of a parent type.

With the move to all-layers, we have a bug where
    export type Person = Patient;
but even though Person has only one sub-type, Patient, we still want
to be able to declare objects with type Person.