### PR TITLE
Support for Custom ontology in CLI

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -15,13 +15,40 @@
  */
 import {ArgumentParser} from 'argparse';
 
-export interface Options {
-  verbose: boolean;
+export interface StandardOntology {
+  /**
+   * The version of the schema to use, formatted as a string.
+   * @example
+   * "3.4"
+   */
   schema: string;
+
+  /**
+   * The "layer" of the schema to use.
+   * @example <caption>The "Standard" approved schema</caption>
+   * "schema"
+   * @example <caption> Standard and pending schema, and extensions available
+   * on Schema.org</caption>
+   * "all-layers"
+   */
   layer: string;
+}
+export interface CustomOntology {
+  /** HTTPS URL to an .nt file defining a custom ontology. */
+  ontology: string;
+}
+
+export type Options = (StandardOntology|CustomOntology)&{
+  verbose: boolean;
   deprecated: boolean;
   context: string;
+};
+
+export function IsCustom(options: StandardOntology|
+                         CustomOntology): options is CustomOntology {
+  return typeof (options as Partial<CustomOntology>).ontology === 'string';
 }
+
 export function ParseFlags(): Options|undefined {
   const parser = new ArgumentParser(
       {version: '0.0.1', addHelp: true, description: 'schema-dts generator'});
@@ -54,6 +81,15 @@ export function ParseFlags(): Options|undefined {
         'property, and \'schema:\' being a prefix for any Schema.org property.',
     metavar: 'key1:url,key2:url,...',
     dest: 'context'
+  });
+  parser.addArgument('--ontology', {
+    defaultValue: undefined,
+    help: 'HTTPS URL to a custom .nt file defining an entirely self-' +
+        'sufficient schema. The schema must still be described in terms of ' +
+        'Schema.org DataTypes, as well as rdf/rdfs concepts like \'type\', ' +
+        '\'domainIncludes\', and \'rangeIncludes\'.',
+    metavar: 'https://url.to/schema.nt',
+    dest: 'ontology'
   });
 
   const deprecated = parser.addMutuallyExclusiveGroup({required: false});

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -19,7 +19,7 @@ import {WriteDeclarations} from '../transform/transform';
 import {load} from '../triples/reader';
 import {Context} from '../ts/context';
 
-import {ParseFlags} from './args';
+import {IsCustom, ParseFlags} from './args';
 
 function parseContext(flag: string) {
   const keyVals = flag.split(',');
@@ -44,7 +44,11 @@ async function main() {
   if (!options) return;
   SetOptions(options);
 
-  const result = load(options.schema, options.layer);
+  const ontologyUrl = IsCustom(options) ?
+      options.ontology :
+      `https://schema.org/version/${options.schema}/${options.layer}.nt`;
+
+  const result = load(ontologyUrl);
   const context = parseContext(options.context);
   await WriteDeclarations(result, options.deprecated, context, write);
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {SetOptions} from '../logging';
+import {Log, SetOptions} from '../logging';
 import {WriteDeclarations} from '../transform/transform';
 import {load} from '../triples/reader';
 import {Context} from '../ts/context';
@@ -47,6 +47,7 @@ async function main() {
   const ontologyUrl = IsCustom(options) ?
       options.ontology :
       `https://schema.org/version/${options.schema}/${options.layer}.nt`;
+  Log(`Loading Ontology from URL: ${ontologyUrl}`);
 
   const result = load(ontologyUrl);
   const context = parseContext(options.context);

--- a/src/triples/reader.ts
+++ b/src/triples/reader.ts
@@ -67,11 +67,11 @@ export function toTripleStrings(data: string[]) {
 /**
  * Loads schema all Triples from a given Schema file and version.
  */
-export function load(version: string, fileName: string): Observable<Triple> {
+export function load(url: string): Observable<Triple> {
   return new Observable<Triple>(subscriber => {
     https
         .get(
-            `https://schema.org/version/${version}/${fileName}.nt`,
+            url,
             response => {
               const data: string[] = [];
 


### PR DESCRIPTION
Some limitations:

1. Need to override `--context` separately since we won't know how to infer it, if it is different than `https://schema.org`.
2. Can only provide one file so you can't define a set of layers. The one file needs to completely define all set of classes and types you have.
3. You need to define a top-level `Thing` type for the .ts to be valid. This should constraint should probably change.

Fixes #4 