### PR TITLE
Fix CLI script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts-gen",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "displayName": "schema-dts Generator",
   "description": "Generate TypeScript Definitions for Schema.org Schema",
   "authors": [
@@ -29,12 +29,12 @@
     "gulp-file": "^0.4.0",
     "gulp-typescript": "^5.0.0-alpha.3",
     "jasmine": "^3.3.1",
-    "rxjs": "^6.3.3",
     "through2": "^3.0.0",
     "tslint": "^5.11.0",
     "typescript": "^3.1.6"
   },
   "dependencies": {
+    "rxjs": "^6.3.3",
     "argparse": "^1.0.10",
     "htmlparser2": "^3.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts-gen",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "displayName": "schema-dts Generator",
   "description": "Generate TypeScript Definitions for Schema.org Schema",
   "authors": [

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,3 +1,5 @@
+#! /usr/bin/env node
+
 /**
  * Copyright 2018 Google LLC
  *


### PR DESCRIPTION
Fixes #16

1. Add shebang header to CLI to make it executable by node.
2. Also include RXJS.

Note that 'typescript' is a peer dependency of the CLI so installing schema-dts-gen is not sufficient, you'll want to also pick your own typescript version to have installed.
