### PR TITLE
Restructure types to be less confusing.

### DIFF
--- a/tests/baselines/comments.ts.txt
+++ b/tests/baselines/comments.ts.txt
@@ -27,7 +27,6 @@ export type Text = string;
 export type Time = string;
 
 type ThingBase = {
-    "@type": "Thing";
     /** Names are great! {@link X Y} */
     "name"?: Text | Text[];
 };
@@ -38,5 +37,7 @@ type ThingBase = {
  * - Bar
  * - _Baz_, and __Bat__
  */
-export type Thing = ThingBase;
+export type Thing = {
+    "@type": "Thing";
+} & ThingBase;
 

--- a/tests/baselines/inheritance_multiple.ts.txt
+++ b/tests/baselines/inheritance_multiple.ts.txt
@@ -27,10 +27,11 @@ export type Text = string;
 export type Time = string;
 
 type PersonBase = ThingBase & {
-    "@type": "Person";
     "height"?: Number | Number[];
 };
-export type Person = PersonBase;
+export type Person = {
+    "@type": "Person";
+} & PersonBase;
 
 type ThingBase = {
     "name"?: Text | Text[];
@@ -40,8 +41,9 @@ export type Thing = ({
 } & ThingBase) | (Person | Vehicle);
 
 type VehicleBase = ThingBase & {
-    "@type": "Vehicle";
     "doors"?: Number | Number[];
 };
-export type Vehicle = VehicleBase;
+export type Vehicle = {
+    "@type": "Vehicle";
+} & VehicleBase;
 

--- a/tests/baselines/inheritance_one.ts.txt
+++ b/tests/baselines/inheritance_one.ts.txt
@@ -27,10 +27,11 @@ export type Text = string;
 export type Time = string;
 
 type PersonBase = ThingBase & {
-    "@type": "Person";
     "height"?: Number | Number[];
 };
-export type Person = PersonBase;
+export type Person = {
+    "@type": "Person";
+} & PersonBase;
 
 type ThingBase = {
     "name"?: Text | Text[];

--- a/tests/baselines/simple.ts.txt
+++ b/tests/baselines/simple.ts.txt
@@ -27,8 +27,9 @@ export type Text = string;
 export type Time = string;
 
 type ThingBase = {
-    "@type": "Thing";
     "name"?: Text | Text[];
 };
-export type Thing = ThingBase;
+export type Thing = {
+    "@type": "Thing";
+} & ThingBase;
 

--- a/tests/baselines/sorted_enum.ts.txt
+++ b/tests/baselines/sorted_enum.ts.txt
@@ -32,8 +32,8 @@ export enum ThingEnum {
     c = "http://schema.org/c",
     d = "http://schema.org/d"
 }
-type ThingBase = {
+type ThingBase = {};
+export type Thing = ThingEnum | ({
     "@type": "Thing";
-};
-export type Thing = ThingEnum | (ThingBase);
+} & ThingBase);
 

--- a/tests/baselines/sorted_props.ts.txt
+++ b/tests/baselines/sorted_props.ts.txt
@@ -27,11 +27,12 @@ export type Text = string;
 export type Time = string;
 
 type ThingBase = {
-    "@type": "Thing";
     "a"?: Text | Text[];
     "b"?: Text | Text[];
     "c"?: Text | Text[];
     "d"?: Text | Text[];
 };
-export type Thing = ThingBase;
+export type Thing = {
+    "@type": "Thing";
+} & ThingBase;
 

--- a/tests/baselines/sorted_proptypes.ts.txt
+++ b/tests/baselines/sorted_proptypes.ts.txt
@@ -27,8 +27,9 @@ export type Text = string;
 export type Time = string;
 
 type ThingBase = {
-    "@type": "Thing";
     "a"?: (Boolean | Date | DateTime | Number | Text | Time) | (Boolean | Date | DateTime | Number | Text | Time)[];
 };
-export type Thing = ThingBase;
+export type Thing = {
+    "@type": "Thing";
+} & ThingBase;
 


### PR DESCRIPTION
Seeing xBase types where some have a "@type" property, and
some do not is confusing. Make sure that all base properities are
easily extensible, and always encode @type on the "total" type.