### PR TITLE
Fix types derived transitively from DataType.

### DIFF
--- a/tests/baselines/url.nt
+++ b/tests/baselines/url.nt
@@ -1,0 +1,4 @@
+<http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#comment> "Data type: URL." .
+<http://schema.org/URL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#label> "URL" .
+<http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Text> .

--- a/tests/baselines/url.ts.txt
+++ b/tests/baselines/url.ts.txt
@@ -1,0 +1,32 @@
+// tslint:disable
+
+/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+
+/** Boolean: True or False. */
+export enum Boolean {
+    True = "https://schema.org/True",
+    False = "https://schema.org/False"
+}
+
+/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
+export type Date = string;
+
+/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
+export type DateTime = string;
+
+/** Data type: Number. */
+export type Number = number;
+
+/** Data type: Text. */
+export type Text = string;
+
+/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
+export type Time = string;
+
+type URLBase = Text;
+/** Data type: URL. */
+export type URL = URLBase;
+


### PR DESCRIPTION
A class that inherits from DataType:
1. Is not represented by a JSON-LD node type
2. Does not have any properties on it
3. Does not have a "@type"-tagged leaf type.

Take URL for example, which inerits from Text, a DataType
representing a string. URL can only be represented as a string.

The Class.prototype.aliasesBuiltin method was unused, therein
lied the problem. Use that method to decide if the nonEnumType
should contain a leaf type or not.

There's an overdue refactor here to clean up these types.

Diff in generated schema:
https://www.diffchecker.com/Tmi8bLpL

Fixes #24 