### PR TITLE
Factor out common 'header' for all baselines.

### DIFF
--- a/tests/baseline_test.ts
+++ b/tests/baseline_test.ts
@@ -82,12 +82,14 @@ describe('Baseline', () => {
   beforeEach(() => {
     addMatchers();
   });
+  const header =
+      readFileSync(`tests/baselines/common/header.ts.txt`).toString('utf-8');
 
   for (const {input, spec, name} of getInputFiles()) {
     it(name, async () => {
       const triples = getTriples(input);
       const result = await getResult(triples);
-      const specValue = readFileSync(spec).toString('utf-8');
+      const specValue = header + '\n' + readFileSync(spec).toString('utf-8');
       expect(result).toDiffCleanlyWith(specValue);
     });
   }

--- a/tests/baselines/comments.ts.txt
+++ b/tests/baselines/comments.ts.txt
@@ -1,35 +1,3 @@
-// tslint:disable
-
-/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
-};
-
-/** Boolean: True or False. */
-export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
-export const Boolean = {
-    True: ("https://schema.org/True" as const),
-    False: ("https://schema.org/False" as const)
-};
-
-/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-export type Date = string;
-
-/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-export type DateTime = string;
-
-/** Data type: Number. */
-export type Number = number;
-
-/** Data type: Text. */
-export type Text = string;
-
-/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-export type Time = string;
-
-/** The basic data types such as Integers, Strings, etc. */
-export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;

--- a/tests/baselines/common/header.ts.txt
+++ b/tests/baselines/common/header.ts.txt
@@ -1,0 +1,31 @@
+// tslint:disable
+
+/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+
+/** Boolean: True or False. */
+export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
+export const Boolean = {
+    True: ("https://schema.org/True" as const),
+    False: ("https://schema.org/False" as const)
+};
+
+/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
+export type Date = string;
+
+/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
+export type DateTime = string;
+
+/** Data type: Number. */
+export type Number = number;
+
+/** Data type: Text. */
+export type Text = string;
+
+/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
+export type Time = string;
+
+/** The basic data types such as Integers, Strings, etc. */
+export type DataType = Text | Number | Time | Date | DateTime | Boolean;

--- a/tests/baselines/inheritance_multiple.ts.txt
+++ b/tests/baselines/inheritance_multiple.ts.txt
@@ -1,35 +1,3 @@
-// tslint:disable
-
-/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
-};
-
-/** Boolean: True or False. */
-export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
-export const Boolean = {
-    True: ("https://schema.org/True" as const),
-    False: ("https://schema.org/False" as const)
-};
-
-/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-export type Date = string;
-
-/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-export type DateTime = string;
-
-/** Data type: Number. */
-export type Number = number;
-
-/** Data type: Text. */
-export type Text = string;
-
-/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-export type Time = string;
-
-/** The basic data types such as Integers, Strings, etc. */
-export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
 type PersonBase = ThingBase & {
     "height"?: Number | Number[];
 };

--- a/tests/baselines/inheritance_one.ts.txt
+++ b/tests/baselines/inheritance_one.ts.txt
@@ -1,35 +1,3 @@
-// tslint:disable
-
-/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
-};
-
-/** Boolean: True or False. */
-export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
-export const Boolean = {
-    True: ("https://schema.org/True" as const),
-    False: ("https://schema.org/False" as const)
-};
-
-/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-export type Date = string;
-
-/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-export type DateTime = string;
-
-/** Data type: Number. */
-export type Number = number;
-
-/** Data type: Text. */
-export type Text = string;
-
-/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-export type Time = string;
-
-/** The basic data types such as Integers, Strings, etc. */
-export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
 type PersonBase = ThingBase & {
     "height"?: Number | Number[];
 };

--- a/tests/baselines/quantities.ts.txt
+++ b/tests/baselines/quantities.ts.txt
@@ -1,35 +1,3 @@
-// tslint:disable
-
-/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
-};
-
-/** Boolean: True or False. */
-export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
-export const Boolean = {
-    True: ("https://schema.org/True" as const),
-    False: ("https://schema.org/False" as const)
-};
-
-/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-export type Date = string;
-
-/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-export type DateTime = string;
-
-/** Data type: Number. */
-export type Number = number;
-
-/** Data type: Text. */
-export type Text = string;
-
-/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-export type Time = string;
-
-/** The basic data types such as Integers, Strings, etc. */
-export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
 type DistanceBase = QuantityBase;
 export type Distance = ({
     "@type": "Distance";

--- a/tests/baselines/simple.ts.txt
+++ b/tests/baselines/simple.ts.txt
@@ -1,35 +1,3 @@
-// tslint:disable
-
-/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
-};
-
-/** Boolean: True or False. */
-export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
-export const Boolean = {
-    True: ("https://schema.org/True" as const),
-    False: ("https://schema.org/False" as const)
-};
-
-/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-export type Date = string;
-
-/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-export type DateTime = string;
-
-/** Data type: Number. */
-export type Number = number;
-
-/** Data type: Text. */
-export type Text = string;
-
-/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-export type Time = string;
-
-/** The basic data types such as Integers, Strings, etc. */
-export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;

--- a/tests/baselines/sorted_enum.ts.txt
+++ b/tests/baselines/sorted_enum.ts.txt
@@ -1,35 +1,3 @@
-// tslint:disable
-
-/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
-};
-
-/** Boolean: True or False. */
-export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
-export const Boolean = {
-    True: ("https://schema.org/True" as const),
-    False: ("https://schema.org/False" as const)
-};
-
-/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-export type Date = string;
-
-/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-export type DateTime = string;
-
-/** Data type: Number. */
-export type Number = number;
-
-/** Data type: Text. */
-export type Text = string;
-
-/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-export type Time = string;
-
-/** The basic data types such as Integers, Strings, etc. */
-export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
 export enum ThingEnum {
     a = "http://schema.org/a",
     b = "http://schema.org/b",

--- a/tests/baselines/sorted_props.ts.txt
+++ b/tests/baselines/sorted_props.ts.txt
@@ -1,35 +1,3 @@
-// tslint:disable
-
-/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
-};
-
-/** Boolean: True or False. */
-export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
-export const Boolean = {
-    True: ("https://schema.org/True" as const),
-    False: ("https://schema.org/False" as const)
-};
-
-/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-export type Date = string;
-
-/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-export type DateTime = string;
-
-/** Data type: Number. */
-export type Number = number;
-
-/** Data type: Text. */
-export type Text = string;
-
-/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-export type Time = string;
-
-/** The basic data types such as Integers, Strings, etc. */
-export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;

--- a/tests/baselines/sorted_proptypes.ts.txt
+++ b/tests/baselines/sorted_proptypes.ts.txt
@@ -1,35 +1,3 @@
-// tslint:disable
-
-/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
-};
-
-/** Boolean: True or False. */
-export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
-export const Boolean = {
-    True: ("https://schema.org/True" as const),
-    False: ("https://schema.org/False" as const)
-};
-
-/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-export type Date = string;
-
-/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-export type DateTime = string;
-
-/** Data type: Number. */
-export type Number = number;
-
-/** Data type: Text. */
-export type Text = string;
-
-/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-export type Time = string;
-
-/** The basic data types such as Integers, Strings, etc. */
-export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;

--- a/tests/baselines/url.ts.txt
+++ b/tests/baselines/url.ts.txt
@@ -1,35 +1,3 @@
-// tslint:disable
-
-/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends Thing> = T & {
-    "@context": "https://schema.org";
-};
-
-/** Boolean: True or False. */
-export type Boolean = true | false | "https://schema.org/True" | "https://schema.org/False";
-export const Boolean = {
-    True: ("https://schema.org/True" as const),
-    False: ("https://schema.org/False" as const)
-};
-
-/** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-export type Date = string;
-
-/** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-export type DateTime = string;
-
-/** Data type: Number. */
-export type Number = number;
-
-/** Data type: Text. */
-export type Text = string;
-
-/** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-export type Time = string;
-
-/** The basic data types such as Integers, Strings, etc. */
-export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
 type URLBase = Text;
 /** Data type: URL. */
 export type URL = URLBase;


### PR DESCRIPTION
All outputs of schema-dts will contain the Schema.org DataTypes, a
`WithContext<T>` definition, and header comments. Rather than have these
in each baseline, factor them out into a common header. This allows us
to change less files at a time when a header changes. This should help
more as we add more baseline tests.