### PR TITLE
Revamp Enum type generation.

### DIFF
--- a/src/ts/enum.ts
+++ b/src/ts/enum.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {createEnumMember, createStringLiteral} from 'typescript';
+import {createAsExpression, createLiteralTypeNode, createPropertyAssignment, createStringLiteral, createTypeReferenceNode} from 'typescript';
 
 import {ObjectPredicate, TSubject, TTypeName} from '../triples/triple';
 import {GetComment, IsClassType, IsDataType} from '../triples/wellKnown';
@@ -73,8 +73,14 @@ export class EnumValue {
   toNode() {
     return withComments(
         this.comment,
-        createEnumMember(
+        createPropertyAssignment(
             toEnumName(this.value),
-            createStringLiteral(this.value.toString())));
+            createAsExpression(
+                createStringLiteral(this.value.toString()),
+                createTypeReferenceNode('const', undefined))));
+  }
+
+  toTypeLiteral() {
+    return createLiteralTypeNode(createStringLiteral(this.value.toString()));
   }
 }

--- a/tests/baselines/sorted_enum.ts.txt
+++ b/tests/baselines/sorted_enum.ts.txt
@@ -1,14 +1,18 @@
-export enum ThingEnum {
-    a = "http://schema.org/a",
-    b = "http://schema.org/b",
-    c = "http://schema.org/c",
-    d = "http://schema.org/d"
-}
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
 };
-export type Thing = ThingEnum | ({
+export type Thing = "http://schema.org/a" | "http://schema.org/b" | "http://schema.org/c" | "http://schema.org/d" | ({
     "@type": "Thing";
 } & ThingBase);
+export const Thing = {
+    a: ("http://schema.org/a" as const),
+    b: ("http://schema.org/b" as const),
+    c: ("http://schema.org/c" as const),
+    d: ("http://schema.org/d" as const)
+};
+/** @deprecated Use Thing as a variable instead. */
+export const ThingEnum = Thing;
+/** @deprecated Use Thing as a type instead. */
+export type ThingEnum = Thing;
 


### PR DESCRIPTION
Inspired by #40 and, to an extent, by #37:

Given an object of name 'Foo' which has enum types, we now allow the
name 'Foo' itself to both refer to the total type (as currently), and
the prefix for the specific enum values.

So all of `let x: Foo;`, `let x = Foo.SOME_VALUE`, as well as
`let.x: Foo = Foo.SOME_VALUE` are valid.

Deprecate `FooEnum`, introducing instead temporary aliases:
`export const FooEnum = Foo;` and
`export type FooEnum = Foo;`.

We'll remove these before 1.0.