### PR TITLE
Declare Arrays in JSON-LD as readonly. 

### DIFF
--- a/src/ts/property.ts
+++ b/src/ts/property.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {createArrayTypeNode, createKeywordTypeNode, createPropertySignature, createStringLiteral, createToken, createTypeReferenceNode, createUnionTypeNode, PropertySignature, SyntaxKind} from 'typescript';
+import {createArrayTypeNode, createKeywordTypeNode, createPropertySignature, createStringLiteral, createToken, createTypeOperatorNode, createTypeReferenceNode, createUnionTypeNode, PropertySignature, SyntaxKind} from 'typescript';
 
 import {Log} from '../logging';
 import {Format, ObjectPredicate, TObject, TSubject} from '../triples/triple';
@@ -108,7 +108,11 @@ export class Property {
 
   private typeNode() {
     const node = this.type.scalarTypeNode();
-    return createUnionTypeNode([node, createArrayTypeNode(node)]);
+    return createUnionTypeNode([
+      node,
+      createTypeOperatorNode(
+          SyntaxKind.ReadonlyKeyword, createArrayTypeNode(node))
+    ]);
   }
 
   toNode(context: Context): PropertySignature {

--- a/tests/baselines/comments.ts.txt
+++ b/tests/baselines/comments.ts.txt
@@ -2,7 +2,7 @@ type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
     /** Names are great! {@link X Y} */
-    "name"?: Text | Text[];
+    "name"?: Text | readonly Text[];
 };
 /**
  * Things are amazing!

--- a/tests/baselines/inheritance_multiple.ts.txt
+++ b/tests/baselines/inheritance_multiple.ts.txt
@@ -1,5 +1,5 @@
 type PersonLikeBase = ThingBase & {
-    "height"?: Number | Number[];
+    "height"?: Number | readonly Number[];
 };
 export type PersonLike = {
     "@type": "PersonLike";
@@ -8,14 +8,14 @@ export type PersonLike = {
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
-    "name"?: Text | Text[];
+    "name"?: Text | readonly Text[];
 };
 export type Thing = ({
     "@type": "Thing";
 } & ThingBase) | (PersonLike | Vehicle);
 
 type VehicleBase = ThingBase & {
-    "doors"?: Number | Number[];
+    "doors"?: Number | readonly Number[];
 };
 export type Vehicle = {
     "@type": "Vehicle";

--- a/tests/baselines/inheritance_one.ts.txt
+++ b/tests/baselines/inheritance_one.ts.txt
@@ -1,5 +1,5 @@
 type PersonLikeBase = ThingBase & {
-    "height"?: Number | Number[];
+    "height"?: Number | readonly Number[];
 };
 export type PersonLike = {
     "@type": "PersonLike";
@@ -8,7 +8,7 @@ export type PersonLike = {
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
-    "name"?: Text | Text[];
+    "name"?: Text | readonly Text[];
 };
 export type Thing = ({
     "@type": "Thing";

--- a/tests/baselines/quantities.ts.txt
+++ b/tests/baselines/quantities.ts.txt
@@ -31,7 +31,7 @@ export type Quantity = ({
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
-    "name"?: Text | Text[];
+    "name"?: Text | readonly Text[];
 };
 export type Thing = ({
     "@type": "Thing";

--- a/tests/baselines/simple.ts.txt
+++ b/tests/baselines/simple.ts.txt
@@ -1,7 +1,7 @@
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
-    "name"?: Text | Text[];
+    "name"?: Text | readonly Text[];
 };
 export type Thing = {
     "@type": "Thing";

--- a/tests/baselines/sorted_props.ts.txt
+++ b/tests/baselines/sorted_props.ts.txt
@@ -1,10 +1,10 @@
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
-    "a"?: Text | Text[];
-    "b"?: Text | Text[];
-    "c"?: Text | Text[];
-    "d"?: Text | Text[];
+    "a"?: Text | readonly Text[];
+    "b"?: Text | readonly Text[];
+    "c"?: Text | readonly Text[];
+    "d"?: Text | readonly Text[];
 };
 export type Thing = {
     "@type": "Thing";

--- a/tests/baselines/sorted_proptypes.ts.txt
+++ b/tests/baselines/sorted_proptypes.ts.txt
@@ -1,7 +1,7 @@
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
-    "a"?: (Boolean | Date | DateTime | Number | Text | Time) | (Boolean | Date | DateTime | Number | Text | Time)[];
+    "a"?: (Boolean | Date | DateTime | Number | Text | Time) | readonly (Boolean | Date | DateTime | Number | Text | Time)[];
 };
 export type Thing = {
     "@type": "Thing";

--- a/tests/baselines/stringlike_http.ts.txt
+++ b/tests/baselines/stringlike_http.ts.txt
@@ -4,17 +4,17 @@ export type EntryPoint = ({
 } & EntryPointBase) | string;
 
 type OrganizationBase = ThingBase & {
-    "locatedIn"?: Place | Place[];
-    "owner"?: Person | Person[];
-    "urlTemplate"?: URL | URL[];
+    "locatedIn"?: Place | readonly Place[];
+    "owner"?: Person | readonly Person[];
+    "urlTemplate"?: URL | readonly URL[];
 };
 export type Organization = ({
     "@type": "Organization";
 } & OrganizationBase) | string;
 
 type PersonBase = ThingBase & {
-    "height"?: Quantity | Quantity[];
-    "locatedIn"?: Place | Place[];
+    "height"?: Quantity | readonly Quantity[];
+    "locatedIn"?: Place | readonly Place[];
 };
 export type Person = ({
     "@type": "Person";
@@ -33,7 +33,7 @@ export type Quantity = ({
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
-    "name"?: Text | Text[];
+    "name"?: Text | readonly Text[];
 };
 export type Thing = ({
     "@type": "Thing";

--- a/tests/baselines/stringlike_https.ts.txt
+++ b/tests/baselines/stringlike_https.ts.txt
@@ -4,17 +4,17 @@ export type EntryPoint = ({
 } & EntryPointBase) | string;
 
 type OrganizationBase = ThingBase & {
-    "locatedIn"?: Place | Place[];
-    "owner"?: Person | Person[];
-    "urlTemplate"?: URL | URL[];
+    "locatedIn"?: Place | readonly Place[];
+    "owner"?: Person | readonly Person[];
+    "urlTemplate"?: URL | readonly URL[];
 };
 export type Organization = ({
     "@type": "Organization";
 } & OrganizationBase) | string;
 
 type PersonBase = ThingBase & {
-    "height"?: Quantity | Quantity[];
-    "locatedIn"?: Place | Place[];
+    "height"?: Quantity | readonly Quantity[];
+    "locatedIn"?: Place | readonly Place[];
 };
 export type Person = ({
     "@type": "Person";
@@ -33,7 +33,7 @@ export type Quantity = ({
 type ThingBase = {
     /** IRI identifying the canonical address of this object. */
     "@id"?: string;
-    "name"?: Text | Text[];
+    "name"?: Text | readonly Text[];
 };
 export type Thing = ({
     "@type": "Thing";


### PR DESCRIPTION
This reduces some of the cognitive load, makes completion easier in some cases, and reduces the impact of type checking.

It is also more accurate: JSON-LD only cares that an array can be read (and, in turn, serialized as JSON), not that it can be mutated during runtime.
