### PR TITLE
Bump Schema-DTS to 0.5.0

### DIFF
--- a/dist/schema/package.json
+++ b/dist/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "displayName": "schema-dts: Strongly-typed Schema.org vocabulary declarations",
   "description": "A TypeScript package with latest Schema.org Schema Typings",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts-gen",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "displayName": "schema-dts Generator",
   "description": "Generate TypeScript Definitions for Schema.org Schema",
   "authors": [


### PR DESCRIPTION
This release includes a backwards-incompatible change that removes deprecated
legacy enum declarations from the .d.ts output.