### PR TITLE
Better Log Testing

### DIFF
--- a/src/ts/enum.ts
+++ b/src/ts/enum.ts
@@ -15,6 +15,7 @@
  */
 import {createAsExpression, createLiteralTypeNode, createPropertyAssignment, createStringLiteral, createTypeReferenceNode} from 'typescript';
 
+import {Log} from '../logging';
 import {ObjectPredicate, TSubject, TTypeName} from '../triples/triple';
 import {GetComment, IsClassType, IsDataType} from '../triples/wellKnown';
 
@@ -60,8 +61,9 @@ export class EnumValue {
     const comment = GetComment(value);
     if (comment) {
       if (this.comment) {
-        throw new Error(`Attempt to add comment on ${
-            this.value.toString()} enum but one already exists.`);
+        Log(`Duplicate comments provided on ${
+            this.value
+                .toString()} enum but one already exists. It will be overwritten.`);
       }
       this.comment = comment.comment;
       return true;

--- a/test/baseline_test.ts
+++ b/test/baseline_test.ts
@@ -65,7 +65,7 @@ function getTriples(file: string): Observable<Triple> {
       }));
 }
 
-async function getResult(
+async function getActual(
     triples: Observable<Triple>, includeDeprecated: boolean) {
   const result: string[] = [];
   const context = new Context();
@@ -83,9 +83,9 @@ describe('Baseline', () => {
   for (const {input, spec, name} of getInputFiles()) {
     it(name, async () => {
       const triples = getTriples(input);
-      const result = await getResult(triples, ShouldIncludeDeprecated(name));
+      const actual = await getActual(triples, ShouldIncludeDeprecated(name));
       const specValue = header + '\n' + readFileSync(spec).toString('utf-8');
-      expectNoDiff(result, specValue);
+      expectNoDiff(actual, specValue);
     });
   }
 });

--- a/test/baselines/duplicate_comments.log
+++ b/test/baselines/duplicate_comments.log
@@ -1,0 +1,3 @@
+Duplicate comments provided on class http://schema.org/Thing. It will be overwritten.
+Duplicate comments provided on property http://schema.org/name. It will be overwritten.
+Duplicate comments provided on http://schema.org/Gadget enum but one already exists. It will be overwritten.

--- a/test/baselines/duplicate_comments.nt
+++ b/test/baselines/duplicate_comments.nt
@@ -1,0 +1,12 @@
+<http://schema.org/name> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+<http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/name> <http://www.w3.org/2000/01/rdf-schema#comment> "Simple!" .
+<http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#comment> "Simple!" .
+<http://schema.org/name> <http://www.w3.org/2000/01/rdf-schema#comment> "Names are great!\n <a href=\"X\">Y</a>"@en .
+<http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#comment> "Things are amazing!\n\n<br/><br /><ul><li>Foo</li><li>Bar</li><li><em>Baz</em>, and <strong>Bat</strong></li><ul>"@en .
+<http://schema.org/Widget> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Thing> .
+<http://schema.org/Gadget> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Thing> .
+<http://schema.org/Gadget> <http://www.w3.org/2000/01/rdf-schema#comment> "Simple!" .
+<http://schema.org/Gadget> <http://www.w3.org/2000/01/rdf-schema#comment> "Complex!" .

--- a/test/baselines/duplicate_comments.ts.txt
+++ b/test/baselines/duplicate_comments.ts.txt
@@ -1,0 +1,22 @@
+type ThingBase = {
+    /** IRI identifying the canonical address of this object. */
+    "@id"?: string;
+    /** Names are great! {@link X Y} */
+    "name"?: Text | readonly Text[];
+};
+/**
+ * Things are amazing!
+ *
+ * - Foo
+ * - Bar
+ * - _Baz_, and __Bat__
+ */
+export type Thing = "http://schema.org/Gadget" | "http://schema.org/Widget" | ({
+    "@type": "Thing";
+} & ThingBase);
+export const Thing = {
+    /** Complex! */
+    Gadget: ("http://schema.org/Gadget" as const),
+    Widget: ("http://schema.org/Widget" as const)
+};
+

--- a/test/baselines/property_edge_cases.log
+++ b/test/baselines/property_edge_cases.log
@@ -1,0 +1,2 @@
+Still unadded for property: name:
+	(sameAs, http://www.w3.org/1999/02/22-rdf-syntax-ns#name)

--- a/test/baselines/property_edge_cases.nt
+++ b/test/baselines/property_edge_cases.nt
@@ -1,0 +1,7 @@
+<http://schema.org/name> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+<http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/name> <http://schema.org/sameAs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#name> .
+<http://schema.org/knows> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/knows> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .

--- a/test/baselines/property_edge_cases.ts.txt
+++ b/test/baselines/property_edge_cases.ts.txt
@@ -1,0 +1,10 @@
+type ThingBase = {
+    /** IRI identifying the canonical address of this object. */
+    "@id"?: string;
+    "knows"?: never | readonly never[];
+    "name"?: Text | readonly Text[];
+};
+export type Thing = {
+    "@type": "Thing";
+} & ThingBase;
+

--- a/test/logging/index_test.ts
+++ b/test/logging/index_test.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect} from 'chai';
+import {SinonStub, stub} from 'sinon';
+
+import {Log, SetOptions} from '../../src/logging';
+
+describe('Log', () => {
+  let logErr:
+      SinonStub<Parameters<Console['error']>, ReturnType<Console['error']>>;
+
+  beforeEach(() => {
+    logErr = stub(console, 'error');
+  });
+
+  afterEach(() => {
+    logErr.restore();
+  });
+
+  it('doesn\'t log by default', () => {
+    Log('Foo');
+    expect(logErr.called).to.be.false;
+  });
+
+  it('doesn\'t log when verbose=false', () => {
+    SetOptions({verbose: false});
+    Log('Foo');
+    expect(logErr.called).to.be.false;
+  });
+
+  it('logs when verbose=true', () => {
+    SetOptions({verbose: true});
+    Log('Foo');
+    expect(logErr.calledWith('Foo')).to.be.true;
+  });
+
+  it('stops logging after turned off', () => {
+    SetOptions({verbose: true});
+    Log('Foo');
+    SetOptions({verbose: false});
+    Log('Bar');
+
+    expect(logErr.calledWith('Foo')).to.be.true;
+    expect(logErr.calledWith('Bar')).to.be.false;
+  });
+});


### PR DESCRIPTION
Improves coverage for logging. This adds unit tests for our logging library, but also support for log diffs in baseline tests.

These sets of tests actually help us fix an inconsistency where duplicate Enum Value comments are handled differently than property and class comments.
