### PR TITLE
Update  naming to always require TTypeName.

### DIFF
--- a/src/triples/wellKnown.ts
+++ b/src/triples/wellKnown.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ObjectPredicate, TPredicate, TSubject, TTypeName, TypedTopic} from './triple';
+import {ObjectPredicate, TObject, TPredicate, TSubject, TTypeName, TypedTopic} from './triple';
 import {UrlNode} from './types';
 
 /** Whether the context corresponds to rdf-schema. */
@@ -108,13 +108,18 @@ export function IsType(predicate: TPredicate): boolean {
   return IsRdfSyntax(predicate) && predicate.name === 'type';
 }
 
+/** Returns iff an Object can be described as a Type Name. */
+export function IsTypeName(value: TObject): value is TTypeName {
+  return value.type === 'UrlNode';
+}
+
 /**
  * If an ObjectPredicate corresponds to a
  * http://www.w3.org/1999/02/22-rdf-syntax-ns#type, returns a Type it describes.
  */
 export function GetType(value: ObjectPredicate): TTypeName|null {
   if (IsType(value.Predicate)) {
-    if (value.Object.type === 'Rdfs' || value.Object.type === 'SchemaString') {
+    if (!IsTypeName(value.Object)) {
       throw new Error(`Unexpected type ${value.Object}`);
     }
     return value.Object;

--- a/src/ts/property.ts
+++ b/src/ts/property.ts
@@ -18,18 +18,19 @@ import {createArrayTypeNode, createKeywordTypeNode, createPropertySignature, cre
 
 import {Log} from '../logging';
 import {Format, ObjectPredicate, TObject, TSubject} from '../triples/triple';
-import {GetComment, IsDomainIncludes, IsRangeIncludes, IsSupersededBy} from '../triples/wellKnown';
+import {UrlNode} from '../triples/types';
+import {GetComment, IsDomainIncludes, IsRangeIncludes, IsSupersededBy, IsTypeName} from '../triples/wellKnown';
 
 import {ClassMap} from './class';
 import {Context} from './context';
 import {withComments} from './util/comments';
-import {toTypeName} from './util/names';
+import {toClassName} from './util/names';
 
 /**
  * A "class" of properties, not associated with any particuar object.
  */
 export class PropertyType {
-  private readonly types: TObject[] = [];
+  private readonly types: UrlNode[] = [];
   private _comment?: string;
   private readonly _supersededBy: TObject[] = [];
 
@@ -59,6 +60,9 @@ export class PropertyType {
     }
 
     if (IsRangeIncludes(value.Predicate)) {
+      if (!IsTypeName(value.Object))
+        throw new Error(`Type expected to be a UrlNode always. When adding ${
+            Format(value)} to ${this.subject.toString()}.`);
       this.types.push(value.Object);
       return true;
     }
@@ -83,8 +87,8 @@ export class PropertyType {
 
   scalarTypeNode() {
     const typeNodes =
-        this.types.sort((a, b) => toTypeName(a).localeCompare(toTypeName(b)))
-            .map(type => createTypeReferenceNode(toTypeName(type), []));
+        this.types.sort((a, b) => toClassName(a).localeCompare(toClassName(b)))
+            .map(type => createTypeReferenceNode(toClassName(type), []));
     switch (typeNodes.length) {
       case 0:
         return createKeywordTypeNode(SyntaxKind.NeverKeyword);
@@ -122,8 +126,8 @@ export class Property {
             /* modifiers= */[],
             createStringLiteral(context.getScopedName(this.key)),
             createToken(SyntaxKind.QuestionToken),
-            /*typeNode=*/this.typeNode(),
-            /*initializer=*/undefined,
+            /*typeNode=*/ this.typeNode(),
+            /*initializer=*/ undefined,
             ));
   }
 }
@@ -139,7 +143,7 @@ export class TypeProperty {
         /* typeNode= */
         createTypeReferenceNode(
             `"${context.getScopedName(this.className)}"`,
-            /*typeArguments=*/undefined),
+            /*typeArguments=*/ undefined),
         /* initializer= */ undefined,
     );
   }
@@ -157,7 +161,7 @@ export function IdPropertyNode() {
           /* typeNode= */
           createTypeReferenceNode(
               'string',
-              /*typeArguments=*/undefined),
+              /*typeArguments=*/ undefined),
           /* initializer= */ undefined,
           ));
 }

--- a/test/helpers/make_class.ts
+++ b/test/helpers/make_class.ts
@@ -13,27 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {TSubject, TTypeName} from '../../triples/triple';
+import {UrlNode} from '../../src/triples/types';
+import {Class, ClassMap} from '../../src/ts/class';
 
-function decodeOr(component: string) {
-  try {
-    return decodeURIComponent(component);
-  } catch {
-    return component;
-  }
+export function makeClass(url: string, allowString: boolean = false): Class {
+  return new Class(UrlNode.Parse(url), allowString);
 }
 
-export function toClassName(subject: TTypeName): string {
-  let sanitizedName = decodeOr(subject.name).replace(/[^A-Za-z0-9_]/g, '_');
-
-  // No leading numbers.
-  if (/^[0-9]/g.test(sanitizedName)) {
-    sanitizedName = `_${sanitizedName}`;
-  }
-
-  return sanitizedName;
-}
-
-export function toEnumName(subject: TSubject): string {
-  return (subject.name).replace(/[^A-Za-z0-9_]/g, '_');
+export function makeClassMap(...classes: Class[]): ClassMap {
+  return new Map(classes.map(cls => [cls.subject.href, cls]));
 }

--- a/test/ts/property_test.ts
+++ b/test/ts/property_test.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect} from 'chai';
+
+import {Rdfs, SchemaString, UrlNode} from '../../src/triples/types';
+import {PropertyType} from '../../src/ts/property';
+import {makeClass, makeClassMap} from '../helpers/make_class';
+
+describe('PropertyType', () => {
+  let prop: PropertyType;
+
+  beforeEach(() => {
+    prop = new PropertyType(UrlNode.Parse('https://schema.org/name'));
+  });
+
+  it('initial properties when empty', () => {
+    expect(prop.comment).to.be.undefined;
+    expect(prop.deprecated).to.be.false;
+  });
+
+  describe('add', () => {
+    describe('rangeIncludes', () => {
+      const rangeIncludes = () =>
+          UrlNode.Parse('https://schema.org/rangeIncludes');
+
+      it('non-type rangeIncludes object fails', () => {
+        expect(
+            () => prop.add(
+                {
+                  Predicate: rangeIncludes(),
+                  Object: new SchemaString('foo', 'en')
+                },
+                new Map))
+            .to.throw('Type expected to be a UrlNode');
+
+        expect(
+            () => prop.add(
+                {Predicate: rangeIncludes(), Object: new Rdfs('foo')}, new Map))
+            .to.throw('Type expected to be a UrlNode');
+      });
+
+      it('type rangeIncludes object succeeds', () => {
+        expect(prop.add(
+                   {
+                     Predicate: rangeIncludes(),
+                     Object: UrlNode.Parse('https://schema.org/Thing')
+                   },
+                   new Map))
+            .to.be.true;
+      });
+    });
+  });
+
+  describe('domainIncludes', () => {
+    const domainIncludes = () =>
+        UrlNode.Parse('https://schema.org/domainIncludes');
+    it('failed lookup throws', () => {
+      const classes = makeClassMap(makeClass('https://schema.org/Person'));
+      expect(
+          () => prop.add(
+              {
+                Predicate: domainIncludes(),
+                Object: UrlNode.Parse('https://schema.org/Thing')
+              },
+              classes))
+          .to.throw('Could not find class');
+    });
+
+    it('real lookup works', () => {
+      const classes = makeClassMap(makeClass('https://schema.org/Person'));
+      expect(prop.add(
+                 {
+                   Predicate: domainIncludes(),
+                   Object: UrlNode.Parse('https://schema.org/Person')
+                 },
+                 classes))
+          .to.be.true;
+    });
+  });
+
+  describe('supersededBy', () => {
+    it('always works', () => {
+      expect(prop.add(
+                 {
+                   Predicate: UrlNode.Parse('https://schema.org/supersededBy'),
+                   Object: UrlNode.Parse('https://schema.org/Person')
+                 },
+                 new Map))
+          .to.be.true;
+
+      expect(prop.comment).to.match(/@deprecated/g);
+      expect(prop.deprecated).to.be.true;
+    });
+  });
+
+  describe('comment', () => {
+    const comment = () =>
+        UrlNode.Parse('http://www.w3.org/2000/01/rdf-schema#comment');
+
+    it('works with string', () => {
+      expect(prop.add(
+                 {Predicate: comment(), Object: new SchemaString('foo', 'en')},
+                 new Map))
+          .to.be.true;
+
+      expect(prop.comment).to.match(/foo/g);
+    });
+
+    it('only supports strings as comments', () => {
+      expect(
+          () => prop.add(
+              {
+                Predicate: comment(),
+                Object: UrlNode.Parse('http://schema.org/Amazing')
+              },
+              new Map))
+          .to.throw('non-string object');
+    });
+  });
+});


### PR DESCRIPTION
This results in the removal of toTypeName (toClassName can always be used
instead).

Add tests to exercise cases where we need runtime checks to make sure type names
are well formed.