### PR TITLE
Achieve better test coverage for Triples and Transform functions

### DIFF
--- a/src/transform/toClass.ts
+++ b/src/transform/toClass.ts
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+import {ok} from 'assert';
+
 import {Log} from '../logging';
 import {ObjectPredicate, Topic, TypedTopic} from '../triples/triple';
 import {UrlNode} from '../triples/types';
 import {IsClass} from '../triples/wellKnown';
 import {BooleanEnum, Builtin, Class, ClassMap, DataTypeUnion} from '../ts/class';
+
+const assert: <T>(item: T|undefined) => asserts item is T = ok;
 
 function toClass(cls: Class, topic: Topic, map: ClassMap): Class {
   const rest: ObjectPredicate[] = [];
@@ -87,10 +91,6 @@ function ForwardDeclareClasses(topics: ReadonlyArray<TypedTopic>): ClassMap {
         topic.Subject.toString(), new Class(topic.Subject, allowString));
   }
 
-  if (classes.size === 0) {
-    throw new Error('Expected Class topics to exist.');
-  }
-
   return classes;
 }
 
@@ -99,10 +99,7 @@ function BuildClasses(topics: ReadonlyArray<TypedTopic>, classes: ClassMap) {
     if (!IsClass(topic)) continue;
 
     const cls = classes.get(topic.Subject.toString());
-    if (!cls) {
-      throw new Error(`Class ${
-          topic.Subject.toString()} should have been forward declared.`);
-    }
+    assert(cls);
     toClass(cls, topic, classes);
   }
 }

--- a/src/triples/reader.ts
+++ b/src/triples/reader.ts
@@ -137,6 +137,12 @@ export function* process(triples: string[][]): Iterable<Triple> {
       // certain layer overlays.
       continue;
     }
+
+    // Schema.org 3.4 all-layers used to contain a test comment:
+    // (Subject:    <http://meta.schema.org/>
+    //  Predicate:  <http://www.w3.org/2000/01/rdf-schema#comment>
+    //  Object:     "A test comment.")
+    // We skip it manually.
     if (match[0] === 'http://meta.schema.org/') {
       continue;
     }

--- a/src/triples/reader.ts
+++ b/src/triples/reader.ts
@@ -172,9 +172,9 @@ export function* process(triples: string[][]): Iterable<Triple> {
         Object: object(match[2])
       };
     } catch (parseError) {
-      throw new Error(`${
-          parseError.stack ||
-          String(parseError)} while parsing line ${match}.`);
+      const e = parseError as Error;
+      throw new Error(`ParseError: ${e.name}: ${e.message} while parsing line ${
+          match}.\nOriginal Stack:\n${e.stack}\nRethrown from:`);
     }
   }
 }

--- a/test/triples/reader_test.ts
+++ b/test/triples/reader_test.ts
@@ -18,7 +18,6 @@ import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {ClientRequest, IncomingMessage} from 'http';
 import https from 'https';
-import {Observable} from 'rxjs';
 import {toArray} from 'rxjs/operators';
 import {SinonStub, stub} from 'sinon';
 import {PassThrough, Writable} from 'stream';
@@ -122,6 +121,30 @@ describe('load', () => {
       const control = fakeResponse(200, 'Ok');
       control.data(
           `<https://schema.org/Person> <https://schema.org/knowsAbout> "math" .\n`);
+      control.data(
+          `<https://schema.org/Person> <https://schema.org/knowsAbout> "science" .\n`);
+      control.end();
+
+      await expect(triples).to.eventually.deep.equal([
+        {
+          Subject: UrlNode.Parse('https://schema.org/Person'),
+          Predicate: UrlNode.Parse('https://schema.org/knowsAbout'),
+          Object: SchemaString.Parse('"math"')!,
+        },
+        {
+          Subject: UrlNode.Parse('https://schema.org/Person'),
+          Predicate: UrlNode.Parse('https://schema.org/knowsAbout'),
+          Object: SchemaString.Parse('"science"')!,
+        }
+      ]);
+    });
+
+    it('Multiple (skip test comment)', async () => {
+      const control = fakeResponse(200, 'Ok');
+      control.data(
+          `<https://schema.org/Person> <https://schema.org/knowsAbout> "math" .\n`);
+      control.data(
+          `<http://meta.schema.org/> <http://www.w3.org/2000/01/rdf-schema#comment> "A test comment." .\n`);
       control.data(
           `<https://schema.org/Person> <https://schema.org/knowsAbout> "science" .\n`);
       control.end();

--- a/test/triples/reader_test.ts
+++ b/test/triples/reader_test.ts
@@ -163,6 +163,42 @@ describe('load', () => {
       ]);
     });
 
+    it('Multiple (throws from bad URL: Subject)', async () => {
+      const control = fakeResponse(200, 'Ok');
+      control.data(
+          `<https://schema.org/Person> <https://schema.org/knowsAbout> "math" .\n`);
+      control.data(
+          `<http://schema.org/> <http://www.w3.org/2000/01/rdf-schema#comment> "A test comment." .\n`);
+      control.end();
+
+      await expect(triples).to.eventually.rejectedWith(
+          'ParseError: Error: Unexpected URL');
+    });
+
+    it('Multiple (throws from bad URL: Predicate)', async () => {
+      const control = fakeResponse(200, 'Ok');
+      control.data(
+          `<https://schema.org/Person> <https://schema.org/knowsAbout> "math" .\n`);
+      control.data(
+          `<http://schema.org/A> <https://schema.org> "A test comment." .\n`);
+      control.end();
+
+      await expect(triples).to.eventually.rejectedWith(
+          'ParseError: Error: Unexpected URL');
+    });
+
+    it('Multiple (throws from bad URL: Object)', async () => {
+      const control = fakeResponse(200, 'Ok');
+      control.data(
+          `<https://schema.org/Person> <https://schema.org/knowsAbout> <https://schema.org/> .\n`);
+      control.data(
+          `<http://schema.org/A> <http://www.w3.org/2000/01/rdf-schema#comment> "A test comment." .\n`);
+      control.end();
+
+      await expect(triples).to.eventually.rejectedWith(
+          'ParseError: Error: Unexpected URL');
+    });
+
     it('Multiple (dirty broken)', async () => {
       const control = fakeResponse(200, 'Ok');
       control.data(`<https://schema.org/Person> <https://sc`);

--- a/test/triples/wellKnown_test.ts
+++ b/test/triples/wellKnown_test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 
 import {Rdfs, SchemaString, UrlNode} from '../../src/triples/types';
-import {GetComment, GetSubClassOf, GetType, GetTypes} from '../../src/triples/wellKnown';
+import {GetComment, GetSubClassOf, GetType, GetTypes, IsClass} from '../../src/triples/wellKnown';
 
 describe('wellKnown', () => {
   describe('GetComment', () => {
@@ -200,6 +200,54 @@ describe('wellKnown', () => {
                 }
               ]))
           .to.throw('No type found');
+    });
+  });
+
+  describe('IsClass', () => {
+    const cls = UrlNode.Parse('http://www.w3.org/2000/01/rdf-schema#Class');
+    const dataType = UrlNode.Parse('http://schema.org/DataType');
+    const bool = UrlNode.Parse('http://schema.org/Boolean');
+
+    it('a data type is not a class', () => {
+      expect(IsClass({
+        Subject: UrlNode.Parse('https://schema.org/Text'),
+        types: [cls, dataType],
+        values: []
+      })).to.be.false;
+
+      expect(IsClass({
+        Subject: UrlNode.Parse('https://schema.org/Text'),
+        types: [dataType, cls],
+        values: []
+      })).to.be.false;
+    });
+
+    it('an only-enum is not a class', () => {
+      expect(IsClass({
+        Subject: UrlNode.Parse('https://schema.org/True'),
+        types: [bool],
+        values: []
+      })).to.be.false;
+    });
+
+    it('an enum can still be a class', () => {
+      expect(IsClass({
+        Subject: UrlNode.Parse('https://schema.org/ItsComplicated'),
+        types: [bool, cls],
+        values: []
+      })).to.be.true;
+    });
+
+    it('the DataType union is not a class', () => {
+      expect(IsClass({
+        Subject: UrlNode.Parse('https://schema.org/DataType'),
+        types: [cls],
+        values: [{
+          Predicate:
+              UrlNode.Parse('http://www.w3.org/2000/01/rdf-schema#subClassOf'),
+          Object: UrlNode.Parse('http://www.w3.org/2000/01/rdf-schema#Class')
+        }]
+      })).to.be.false;
     });
   });
 });


### PR DESCRIPTION
- Removes unreachable code from toClass
  > We check for classes.size right after adding wellKnownTypes to that set.
  > It will never be 0.
  > 
  > The assertion in BuildClasses will never be true, since IsClass is the
  > same condition as what causes this content to be added. Instead of
  > bespoke exceptions, we use node's assertion to make sure that this won't
  > happen.
  > 
  > More philosophically, we should use this type of assertion whenever --
  > within the bounds of an exported function -- regardless of its inputs,
  > a certain condition is impossible.
  > 
  > Instead let's just make sure explicit exceptions are used for things that
  > can go wrong in actuality.

- Document reasoning behind a hack in place to avoid a crash when parsing schema.org/3.4/all-layers.nt, where a triple is:
  ```nt
  <http://meta.schema.org/> <http://www.w3.org/2000/01/rdf-schema#comment> "A test comment." .
  ```
  Make sure this case is tested against.

- Better coverage for nested parsing errors.