### PR TITLE
Add tests for arg parsing and reflection.

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -51,7 +51,7 @@ export function IsCustom(options: StandardOntology|
   return typeof (options as Partial<CustomOntology>).ontology === 'string';
 }
 
-export function ParseFlags(): Options|undefined {
+export function ParseFlags(args?: string[]): Options|undefined {
   const parser = new ArgumentParser(
       {version: '0.0.1', addHelp: true, description: 'schema-dts generator'});
 
@@ -97,7 +97,7 @@ export function ParseFlags(): Options|undefined {
 
   const deprecated = parser.addMutuallyExclusiveGroup({required: false});
   deprecated.addArgument('--deprecated', {
-    defaultValue: {defaultValue: true},
+    defaultValue: true,
     help: 'Include deprecated Classes and Properties.',
     action: 'storeTrue',
     dest: 'deprecated'
@@ -107,5 +107,5 @@ export function ParseFlags(): Options|undefined {
     action: 'storeFalse',
     dest: 'deprecated'
   });
-  return parser.parseArgs();
+  return parser.parseArgs(args);
 }

--- a/test/cli/args_test.ts
+++ b/test/cli/args_test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect} from 'chai';
+
+import {CustomOntology, IsCustom, ParseFlags, StandardOntology} from '../../src/cli/args';
+
+describe('ParseFlags', () => {
+  it('defaults', () => {
+    const options = ParseFlags([])!;
+    expect(options).not.to.be.undefined;
+    expect(options.context).to.equal('https://schema.org');
+    expect(options.deprecated).to.be.true;
+    expect(options.verbose).to.be.false;
+    expect(IsCustom(options)).to.be.false;
+
+    const standard = options as StandardOntology;
+    expect(standard.layer).to.equal('all-layers');
+    expect(standard.schema).to.equal('latest');
+  });
+
+  it('custom ontology', () => {
+    const options = ParseFlags(['--ontology', 'https://google.com/foo'])!;
+    expect(options).not.to.be.undefined;
+    expect(IsCustom(options)).to.be.true;
+
+    const custom = options as CustomOntology;
+    expect(custom.ontology).to.equal('https://google.com/foo');
+  });
+});


### PR DESCRIPTION
Uncovers issue with incorrect default value for --deprecated.

Thankfully this was harmless, as that default value was also truthy.