### PR TITLE
Reader Coverage: Restructure assertion code.

### DIFF
--- a/src/transform/toClass.ts
+++ b/src/transform/toClass.ts
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-import {ok} from 'assert';
-
 import {Log} from '../logging';
 import {ObjectPredicate, Topic, TypedTopic} from '../triples/triple';
 import {UrlNode} from '../triples/types';
 import {IsClass} from '../triples/wellKnown';
 import {BooleanEnum, Builtin, Class, ClassMap, DataTypeUnion} from '../ts/class';
-
-const assert: <T>(item: T|undefined) => asserts item is T = ok;
+import {assert} from '../util/assert';
 
 function toClass(cls: Class, topic: Topic, map: ClassMap): Class {
   const rest: ObjectPredicate[] = [];

--- a/src/util/assert.ts
+++ b/src/util/assert.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ok} from 'assert';
+
+export function assert<T>(
+    item: T|null|undefined, message?: string|Error): asserts item is T {
+  ok(item, message);
+}


### PR DESCRIPTION
Per the standard established in #73 (specifically in 11c9f643), use an
external assert function using TypeScript's "asserts" returns for areas
where we structurally expect something to never happen.

In this code, the regex used structurally makes it so that verify will
never throw:

- The first two unWrap() parsing options will only work if the thing
  is wrapped in <>. If it is, but doesn't work, UrlNode throws.
- The the last function throws on malformed string, but the regex
  guarantees that the string is well-formed.

Change this into an assertion. If it happens, its because a structural
assumption made about the code is wrong.

As opposed to other exception places where the error happens not because
of bugs in the code, but because of issues with the data or the inputs.

This factors out assert into its own util file.

Verify is only used in object(), so we inline its logic.