### PR TITLE
Restructure comment handling code.

### DIFF
--- a/src/ts/util/comments.ts
+++ b/src/ts/util/comments.ts
@@ -16,7 +16,10 @@
 
 import {Parser} from 'htmlparser2';
 import {Node, setSyntheticLeadingComments, SyntaxKind} from 'typescript';
+import {assert} from '../../util/assert';
 
+// String Replacement: make sure we replace unicode strings as needed, wherever
+// they show up as text.
 const replacer: Array<[RegExp, string]> = [
   [/\\n/g, ''],
   [/\\u2014/gi, '\u2014'],
@@ -29,66 +32,62 @@ function replace(str: string): string {
   }
   return str;
 }
+
+// Tag Management: Define functions describing what to do with HTML tags in our
+// comments.
+interface OnTag {
+  open?(attrs: {[key: string]: string}): string;
+  close?(): string;
+}
+
+// Some handlers for behaviors that apply to multiple tags:
+const em: OnTag = {
+  open: () => '_',
+  close: () => '_'
+};
+const strong = {
+  open: () => '__',
+  close: () => '__'
+};
+const code = {
+  open: () => '`',
+  close: () => '`'
+};
+
+// Our top-level tag handler.
+const onTag = new Map<string, OnTag>([
+  ['a', {open: (attrs) => `{@link ${attrs['href']} `, close: () => '}'}],
+  ['em', em],
+  ['i', em],
+  ['strong', strong],
+  ['b', strong],
+  ['br', {open: () => '\n', /* Ignore closing of <BR> */}],
+  ['li', {open: () => '- ', close: () => '\n'}],
+  ['ul', {/* Ignore <UL> entirely. */}],
+  ['code', code],
+  ['pre', code],
+]);
+
 function parseComment(comment: string): string {
   const result: string[] = [];
   const parser = new Parser({
     ontext: (text: string) => result.push(replace(text)),
     onopentag: (tag: string, attrs: {[key: string]: string}) => {
-      switch (tag) {
-        case 'a':
-          result.push(`{@link ${attrs['href']} `);
-          break;
-        case 'em':
-        case 'i':
-          result.push('_');
-          break;
-        case 'strong':
-        case 'b':
-          result.push('__');
-          break;
-        case 'br':
-          result.push('\n');
-          break;
-        case 'li':
-          result.push('- ');
-          break;
-        case 'code':
-        case 'pre':
-          result.push('`');
-          break;
-        case 'ul':
-          // Ignore
-          break;
-        default:
-          throw new Error(`Unknown tag "${tag}".`);
+      const handler = onTag.get(tag);
+      if (!handler) {
+        throw new Error(`Unknown tag "${tag}".`);
+      }
+
+      if (handler.open) {
+        result.push(handler.open(attrs));
       }
     },
     onclosetag: (tag: string) => {
-      switch (tag) {
-        case 'a':
-          result.push('}');
-          break;
-        case 'em':
-        case 'i':
-          result.push('_');
-          break;
-        case 'strong':
-        case 'b':
-          result.push('__');
-          break;
-        case 'li':
-          result.push('\n');
-          break;
-        case 'code':
-        case 'pre':
-          result.push('`');
-          break;
-        case 'ul':
-        case 'br':
-          // Ignore
-          break;
-        default:
-          throw new Error(`Unknown tag "${tag}".`);
+      const handler = onTag.get(tag);
+      assert(handler);
+
+      if (handler.close) {
+        result.push(handler.close());
       }
     }
   });


### PR DESCRIPTION
There was an impossibility in error handling where the onCloseTag
branch's default (throw Error) statement was impossible. This is because
we would always throw in onOpenTag first. We will never see a valid
closed tag without an opening.

Further, a lone closed tag will fail to parse as a close tag anyway. So
this just never happened.

One might be tempted to just remove the default in the name of coverage.
But the default line actually gives us some value: If we ever add
something in open, we might know if we forgot ot add it in close.

But that seems like it should be enforced on lint-time or compile-time,
not just if we're lucky to exercise a condition. Ideally, we should let
the compiler guarantee that any opening tag has a corresponding closing
tag. This way, we keep the benefits of this line, and even improve them
to become a compile-time property, while changing the closing logic
to reflect the impossibility of seeing an unknown closing tag.