### PR TITLE
Librarify "Main" function

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -51,7 +51,7 @@ export function IsCustom(options: StandardOntology|
   return typeof (options as Partial<CustomOntology>).ontology === 'string';
 }
 
-export function ParseFlags(args?: string[]): Options|undefined {
+export function ParseFlags(args?: string[]): Options {
   const parser = new ArgumentParser(
       {version: '0.0.1', addHelp: true, description: 'schema-dts generator'});
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -15,32 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import {Log, SetOptions} from '../logging';
-import {WriteDeclarations} from '../transform/transform';
-import {load} from '../triples/reader';
-import {Context} from '../ts/context';
-
-import {IsCustom, ParseFlags} from './args';
-
-async function main() {
-  const options = ParseFlags();
-  if (!options) return;
-  SetOptions(options);
-
-  const ontologyUrl = IsCustom(options) ?
-      options.ontology :
-      `https://schema.org/version/${options.schema}/${options.layer}.nt`;
-  Log(`Loading Ontology from URL: ${ontologyUrl}`);
-
-  const result = load(ontologyUrl);
-  const context = Context.Parse(options.context);
-  await WriteDeclarations(result, options.deprecated, context, write);
-}
-
-function write(content: string) {
-  process.stdout.write(content, 'utf-8');
-}
+import {main} from './internal/main';
 
 main()
     .then(() => {

--- a/src/cli/internal/main.ts
+++ b/src/cli/internal/main.ts
@@ -23,7 +23,6 @@ import {IsCustom, ParseFlags} from '../args';
 
 export async function main(args?: string[]) {
   const options = ParseFlags(args);
-  if (!options) return;
   SetOptions(options);
 
   const ontologyUrl = IsCustom(options) ?

--- a/src/cli/internal/main.ts
+++ b/src/cli/internal/main.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Log, SetOptions} from '../../logging';
+import {WriteDeclarations} from '../../transform/transform';
+import {load} from '../../triples/reader';
+import {Context} from '../../ts/context';
+
+import {IsCustom, ParseFlags} from '../args';
+
+export async function main(args?: string[]) {
+  const options = ParseFlags(args);
+  if (!options) return;
+  SetOptions(options);
+
+  const ontologyUrl = IsCustom(options) ?
+      options.ontology :
+      `https://schema.org/version/${options.schema}/${options.layer}.nt`;
+  Log(`Loading Ontology from URL: ${ontologyUrl}`);
+
+  const result = load(ontologyUrl);
+  const context = Context.Parse(options.context);
+  await WriteDeclarations(result, options.deprecated, context, write);
+}
+
+function write(content: string) {
+  process.stdout.write(content, 'utf-8');
+}

--- a/test/baseline_test.ts
+++ b/test/baseline_test.ts
@@ -18,18 +18,11 @@
  * Triples representing an entire ontology.
  */
 
-import {existsSync, readdirSync, readFile, readFileSync} from 'fs';
+import {existsSync, readdirSync, readFileSync} from 'fs';
 import {parse} from 'path';
-import {from, Observable} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
-
-import {SetOptions} from '../src/logging';
-import {WriteDeclarations} from '../src/transform/transform';
-import {process, toTripleStrings} from '../src/triples/reader';
-import {Triple} from '../src/triples/triple';
-import {Context} from '../src/ts/context';
 
 import {expectNoDiff} from './helpers/baseline';
+import {cliOnFile} from './helpers/main_driver';
 
 function* getInputFiles(): IterableIterator<{
   input: string,
@@ -51,63 +44,21 @@ function* getInputFiles(): IterableIterator<{
   }
 }
 
-function getTriples(file: string): Observable<Triple> {
-  return new Observable<string>(subscriber => {
-           readFile(file, {encoding: 'utf-8'}, (err, data) => {
-             if (err) {
-               subscriber.error(err);
-             } else {
-               subscriber.next(data);
-               subscriber.complete();
-             }
-           });
-         })
-      .pipe(switchMap(contents => {
-        const triples = toTripleStrings([contents]);
-        return from(process(triples));
-      }));
-}
-
-async function getActual(
-    triples: Observable<Triple>, includeDeprecated: boolean) {
-  const result: string[] = [];
-  const context = new Context();
-  context.setUrlContext('https://schema.org');
-  await WriteDeclarations(triples, includeDeprecated, context, content => {
-    result.push(content);
-  });
-  return result.join('');
-}
-
 describe('Baseline', () => {
-  const realErr = console.error;
   const header =
       readFileSync(`test/baselines/common/header.ts.txt`).toString('utf-8');
-  let logs: string[];
-
-  beforeEach(() => {
-    // Save log output.
-    logs = [];
-    console.error = (msg: string) => void logs.push(msg);
-  });
-
-  afterEach(() => {
-    console.error = realErr;
-  });
 
   for (const {input, spec, name, optLog} of getInputFiles()) {
     it(name, async () => {
       const shouldLog = existsSync(optLog);
-      SetOptions({verbose: shouldLog});
 
-      const triples = getTriples(input);
-      const actual = await getActual(triples, ShouldIncludeDeprecated(name));
+      const {actual, actualLogs} = await cliOnFile(
+          input, {includeDeprecated: ShouldIncludeDeprecated(name), shouldLog});
       const specValue = header + '\n' + readFileSync(spec).toString('utf-8');
       expectNoDiff(actual, specValue);
 
       if (shouldLog) {
-        expectNoDiff(
-            logs.join('\n') + '\n', readFileSync(optLog).toString('utf-8'));
+        expectNoDiff(actualLogs, readFileSync(optLog).toString('utf-8'));
       }
     });
   }

--- a/test/baseline_test.ts
+++ b/test/baseline_test.ts
@@ -52,8 +52,11 @@ describe('Baseline', () => {
     it(name, async () => {
       const shouldLog = existsSync(optLog);
 
-      const {actual, actualLogs} = await cliOnFile(
-          input, {includeDeprecated: ShouldIncludeDeprecated(name), shouldLog});
+      const args = ['--ontology', `https://fake.com/${input}`];
+      if (!ShouldIncludeDeprecated(name)) args.push('--nodeprecated');
+      if (shouldLog) args.push('--verbose');
+
+      const {actual, actualLogs} = await cliOnFile(input, args);
       const specValue = header + '\n' + readFileSync(spec).toString('utf-8');
       expectNoDiff(actual, specValue);
 

--- a/test/baseline_test.ts
+++ b/test/baseline_test.ts
@@ -65,6 +65,23 @@ describe('Baseline', () => {
       }
     });
   }
+
+  describe('manual', () => {
+    it('default ontology', async () => {
+      const {actual, actualLogs} = await cliOnFile(
+          'test/baselines/manual/default_ontology.nt', ['--verbose']);
+
+      const expected = header + '\n' +
+          readFileSync(`test/baselines/manual/default_ontology.ts.txt`)
+              .toString('utf-8');
+      const expectedLogs =
+          readFileSync(`test/baselines/manual/default_ontology.log`)
+              .toString('utf-8');
+
+      expectNoDiff(actual, expected);
+      expectNoDiff(actualLogs, expectedLogs);
+    });
+  });
 });
 
 function ShouldIncludeDeprecated(name: string) {

--- a/test/baselines/category.log
+++ b/test/baselines/category.log
@@ -1,1 +1,3 @@
+Loading Ontology from URL: https://fake.com/test/baselines/category.nt
+Got Response 200: Ok.
 Class Distillery: Did not add [(category "issue-743")]

--- a/test/baselines/duplicate_comments.log
+++ b/test/baselines/duplicate_comments.log
@@ -1,3 +1,5 @@
+Loading Ontology from URL: https://fake.com/test/baselines/duplicate_comments.nt
+Got Response 200: Ok.
 Duplicate comments provided on class http://schema.org/Thing. It will be overwritten.
 Duplicate comments provided on property http://schema.org/name. It will be overwritten.
 Duplicate comments provided on http://schema.org/Gadget enum but one already exists. It will be overwritten.

--- a/test/baselines/enum_skipped.log
+++ b/test/baselines/enum_skipped.log
@@ -1,2 +1,4 @@
+Loading Ontology from URL: https://fake.com/test/baselines/enum_skipped.nt
+Got Response 200: Ok.
 For Enum Item c, did not process:
 	(category, "issue-1156")

--- a/test/baselines/manual/default_ontology.log
+++ b/test/baselines/manual/default_ontology.log
@@ -1,0 +1,2 @@
+Loading Ontology from URL: https://schema.org/version/latest/all-layers.nt
+Got Response 200: Ok.

--- a/test/baselines/manual/default_ontology.nt
+++ b/test/baselines/manual/default_ontology.nt
@@ -1,0 +1,1 @@
+<http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .

--- a/test/baselines/manual/default_ontology.ts.txt
+++ b/test/baselines/manual/default_ontology.ts.txt
@@ -1,0 +1,8 @@
+type ThingBase = {
+    /** IRI identifying the canonical address of this object. */
+    "@id"?: string;
+};
+export type Thing = {
+    "@type": "Thing";
+} & ThingBase;
+

--- a/test/baselines/property_edge_cases.log
+++ b/test/baselines/property_edge_cases.log
@@ -1,2 +1,4 @@
+Loading Ontology from URL: https://fake.com/test/baselines/property_edge_cases.nt
+Got Response 200: Ok.
 Still unadded for property: name:
 	(sameAs, http://www.w3.org/1999/02/22-rdf-syntax-ns#name)

--- a/test/helpers/async.ts
+++ b/test/helpers/async.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export function flush(): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, 1);
+  });
+}

--- a/test/helpers/main_driver.ts
+++ b/test/helpers/main_driver.ts
@@ -22,6 +22,7 @@ import {ClientRequest, IncomingMessage} from 'http';
 import https from 'https';
 
 import {main} from '../../src/cli/internal/main';
+import {SetOptions} from '../../src/logging';
 
 import {flush} from './async';
 
@@ -97,5 +98,8 @@ export async function cliOnFile(file: string, args: string[]):
     process.stdout.write = realWrite;
     console.error = realErr;
     https.get = realGet;
+
+    // Always reset verbosity settings.
+    SetOptions({verbose: false});
   }
 }

--- a/test/helpers/main_driver.ts
+++ b/test/helpers/main_driver.ts
@@ -26,10 +26,7 @@ import {main} from '../../src/cli/internal/main';
 
 import {flush} from './async';
 
-export async function cliOnFile(
-    file: string,
-    options:
-        {includeDeprecated: boolean, shouldLog: boolean, contextFlag?: string}):
+export async function cliOnFile(file: string, args: string[]):
     Promise<{actual: string, actualLogs: string}> {
   // Restorables
   const realWrite = process.stdout.write;
@@ -74,11 +71,6 @@ export async function cliOnFile(
   const logs: string[] = [];
 
   try {
-    const args = ['--ontology', `https://fake.com/${file}`];
-    if (!options.includeDeprecated) args.push('--nodeprecated');
-    if (options.shouldLog) args.push('--verbose');
-    if (options.contextFlag) args.push('--context', options.contextFlag);
-
     const wholeProgram = main(args);
     await flush();
 

--- a/test/helpers/main_driver.ts
+++ b/test/helpers/main_driver.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview A simple runner around a mocked version of the CLI's main()
+ * function, for testing.
+ */
+
+import {fail} from 'assert';
+import {readFile} from 'fs';
+import {ClientRequest, IncomingMessage} from 'http';
+import https from 'https';
+
+import {main} from '../../src/cli/internal/main';
+
+import {flush} from './async';
+
+export async function cliOnFile(
+    file: string,
+    options:
+        {includeDeprecated: boolean, shouldLog: boolean, contextFlag?: string}):
+    Promise<{actual: string, actualLogs: string}> {
+  // Restorables
+  const realWrite = process.stdout.write;
+  const realErr = console.error;
+  const realGet = https.get;
+
+  // Controllers
+  let innerOnData: (chunk: Buffer) => void;
+  let innerOnEnd: () => void;
+
+  // Mockables
+  process.stdout.write =
+      ((...params: Parameters<typeof process.stdout.write>): boolean => {
+        const str = params[0];
+        if (typeof str === 'string') {
+          writes.push(str);
+          return true;
+        } else {
+          return realWrite(...params);
+        }
+      }) as typeof process.stdout.write;
+  console.error = (msg: string) => void logs.push(msg);
+
+  // TODO(eyas): A lot of the mocking here is due to the fact that https.get
+  // cannot read local file:/// paths. If it were possible, the get mocking
+  // would go away, making a lot of this much simpler.
+  https.get =
+      ((_: string, callback: (inc: IncomingMessage) => void): ClientRequest => {
+        callback({
+          statusCode: 200,
+          statusMessage: 'Ok',
+          on: (event: string, listener: (arg?: unknown) => void) => {
+            if (event === 'data') innerOnData = listener;
+            if (event === 'end') innerOnEnd = listener;
+          }
+        } as IncomingMessage);
+        return {on: () => {}} as {} as ClientRequest;
+      }) as typeof https.get;
+
+  // Outputs
+  const writes: string[] = [];
+  const logs: string[] = [];
+
+  try {
+    const args = ['--ontology', `https://fake.com/${file}`];
+    if (!options.includeDeprecated) args.push('--nodeprecated');
+    if (options.shouldLog) args.push('--verbose');
+    if (options.contextFlag) args.push('--context', options.contextFlag);
+
+    const wholeProgram = main(args);
+    await flush();
+
+    readFile(file, (err, data) => {
+      if (err) {
+        fail(err);
+      } else {
+        innerOnData(data);
+        innerOnEnd();
+      }
+    });
+
+    await wholeProgram;
+
+    return {
+      actual: writes.join(''),
+      actualLogs: logs.join('\n') + '\n',
+    };
+
+  } finally {
+    process.stdout.write = realWrite;
+    console.error = realErr;
+    https.get = realGet;
+  }
+}

--- a/test/triples/reader_test.ts
+++ b/test/triples/reader_test.ts
@@ -25,6 +25,7 @@ import {PassThrough, Writable} from 'stream';
 import {load} from '../../src/triples/reader';
 import {Triple} from '../../src/triples/triple';
 import {SchemaString, UrlNode} from '../../src/triples/types';
+import {flush} from '../helpers/async';
 
 use(chaiAsPromised);
 
@@ -42,7 +43,7 @@ describe('load', () => {
   it('is lazy', () => {
     load('https://schema.org');
     expect(get.called).to.be.false;
-  })
+  });
 
   it('total fail', async () => {
     const triples$ = load('https://schema.org/');
@@ -405,12 +406,6 @@ describe('load', () => {
 
 function passThrough(): ClientRequest {
   return new PassThrough() as Writable as ClientRequest;
-}
-
-function flush(): Promise<void> {
-  return new Promise(resolve => {
-    setTimeout(resolve, 1);
-  });
 }
 
 interface Control {


### PR DESCRIPTION
Allow the "Main" function to exist outside of cli.js

Use the main method to run baseline tests instead of trying to reimplement pieces of it.

One area where the code suffers as a result (described in 61dee88) is that we have to mock some `https` internals in order to get loading the baseline files to work.

This would be much easier if we used the same library to read both local files (file:///) and https files.

Add tests for some cases that are not directly tested.

By looking at coverage, I got to understand that ParseFlags types were off: they never return `undefined` in reality (instead they directly exit using `process.exit`), so we don't need to do any checking on `options`.