### PR TITLE
Exclude CLI from coverage analysis.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       "gulpfile.js",
       "coverage/**/*",
       "test/**/*",
-      "src/cli/cli.js"
+      "src/cli/cli.ts"
     ],
     "reporter": [
       "html"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
       "dist/**/*",
       "gulpfile.js",
       "coverage/**/*",
-      "test/**/*"
+      "test/**/*",
+      "src/cli/cli.js"
     ],
     "reporter": [
       "html"


### PR DESCRIPTION
Since we finally reduced its number of lines to a minimal amount.