### PR TITLE
Bump schema-dts version to 0.5.2

### DIFF
--- a/dist/schema/package.json
+++ b/dist/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "displayName": "schema-dts: Strongly-typed Schema.org vocabulary declarations",
   "description": "A TypeScript package with latest Schema.org Schema Typings",
   "authors": [


### PR DESCRIPTION
schema-dts-gen doesn't need to change.