### PR TITLE
Name intermediate Leaf types

### DIFF
--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -268,7 +268,7 @@ export class Class {
     );
   }
 
-  private nonEnumType(skipDeprecated: boolean): TypeNode {
+  private nonEnumType(skipDeprecated: boolean): TypeNode[] {
     this.children.sort((a, b) => CompareKeys(a.subject, b.subject));
     const children = this.children
       .filter(child => !(child.deprecated && skipDeprecated))
@@ -281,13 +281,6 @@ export class Class {
       children.push(createTypeReferenceNode('string', /*typeArguments=*/ []));
     }
 
-    const childrenNode =
-      children.length === 0
-        ? null
-        : children.length === 1
-        ? children[0]
-        : createParenthesizedType(createUnionTypeNode(children));
-
     const leafTypeReference = createTypeReferenceNode(
       // If we inherit from a DataType (~= a Built In), then the type is _not_
       // represented as a node. Skip the leaf type.
@@ -298,11 +291,7 @@ export class Class {
       /*typeArguments=*/ []
     );
 
-    if (childrenNode) {
-      return createUnionTypeNode([leafTypeReference, childrenNode]);
-    } else {
-      return leafTypeReference;
-    }
+    return [leafTypeReference, ...children];
   }
 
   private totalType(skipDeprecated: boolean): TypeNode {
@@ -311,10 +300,10 @@ export class Class {
     if (isEnum) {
       return createUnionTypeNode([
         ...this.enums().map(e => e.toTypeLiteral()),
-        createParenthesizedType(this.nonEnumType(skipDeprecated)),
+        ...this.nonEnumType(skipDeprecated),
       ]);
     } else {
-      return this.nonEnumType(skipDeprecated);
+      return createUnionTypeNode(this.nonEnumType(skipDeprecated));
     }
   }
 

--- a/test/baselines/category_test.ts
+++ b/test/baselines/category_test.ts
@@ -72,19 +72,21 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type DistilleryBase = ThingBase;
-    /** A distillery. */
-    export type Distillery = {
+    type DistilleryLeaf = {
         \\"@type\\": \\"Distillery\\";
     } & DistilleryBase;
+    /** A distillery. */
+    export type Distillery = DistilleryLeaf;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
         \\"name\\"?: Text | readonly Text[];
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | Distillery;
+    } & ThingBase;
+    export type Thing = ThingLeaf | Distillery;
 
     "
   `);

--- a/test/baselines/comments_test.ts
+++ b/test/baselines/comments_test.ts
@@ -84,6 +84,9 @@ test(`baseine_${basename(__filename)}`, async () => {
         /** Names are great! {@link X Y} */
         \\"name\\"?: Text | readonly Text[];
     };
+    type ThingLeaf = {
+        \\"@type\\": \\"Thing\\";
+    } & ThingBase;
     /**
      * Things are amazing!
      *
@@ -91,9 +94,7 @@ test(`baseine_${basename(__filename)}`, async () => {
      * - Bar
      * - _Baz_, and __Bat__
      */
-    export type Thing = {
-        \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    export type Thing = ThingLeaf;
 
     "
   `);

--- a/test/baselines/default_ontology_test.ts
+++ b/test/baselines/default_ontology_test.ts
@@ -66,9 +66,10 @@ test(`baseine_${basename(__filename)}`, async () => {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
     };
-    export type Thing = {
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
+    export type Thing = ThingLeaf;
 
     "
   `);

--- a/test/baselines/deprecated_objects_test.ts
+++ b/test/baselines/deprecated_objects_test.ts
@@ -92,16 +92,18 @@ test(`baseine_${basename(__filename)}`, async () => {
     type CarBase = ThingBase & {
         \\"doorNumber\\"?: Number | readonly Number[];
     };
-    export type Car = {
+    type CarLeaf = {
         \\"@type\\": \\"Car\\";
     } & CarBase;
+    export type Car = CarLeaf;
 
     type PersonLikeBase = ThingBase & {
         \\"height\\"?: Number | readonly Number[];
     };
-    export type PersonLike = {
+    type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
     } & PersonLikeBase;
+    export type PersonLike = PersonLikeLeaf;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
@@ -113,19 +115,21 @@ test(`baseine_${basename(__filename)}`, async () => {
          */
         \\"names\\"?: Text | readonly Text[];
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | (Car | PersonLike | Vehicle);
+    } & ThingBase;
+    export type Thing = ThingLeaf | (Car | PersonLike | Vehicle);
 
     type VehicleBase = ThingBase & {
         \\"doorNumber\\"?: Number | readonly Number[];
         /** @deprecated Consider using http://schema.org/doorNumber instead. */
         \\"doors\\"?: Number | readonly Number[];
     };
-    /** @deprecated Use Car instead. */
-    export type Vehicle = {
+    type VehicleLeaf = {
         \\"@type\\": \\"Vehicle\\";
     } & VehicleBase;
+    /** @deprecated Use Car instead. */
+    export type Vehicle = VehicleLeaf;
 
     "
   `);

--- a/test/baselines/deprecated_objects_test.ts
+++ b/test/baselines/deprecated_objects_test.ts
@@ -118,7 +118,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
-    export type Thing = ThingLeaf | (Car | PersonLike | Vehicle);
+    export type Thing = ThingLeaf | Car | PersonLike | Vehicle;
 
     type VehicleBase = ThingBase & {
         \\"doorNumber\\"?: Number | readonly Number[];

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -79,6 +79,9 @@ test(`baseine_${basename(__filename)}`, async () => {
         /** Names are great! {@link X Y} */
         \\"name\\"?: Text | readonly Text[];
     };
+    type ThingLeaf = {
+        \\"@type\\": \\"Thing\\";
+    } & ThingBase;
     /**
      * Things are amazing!
      *
@@ -86,9 +89,7 @@ test(`baseine_${basename(__filename)}`, async () => {
      * - Bar
      * - _Baz_, and __Bat__
      */
-    export type Thing = \\"http://schema.org/Gadget\\" | \\"http://schema.org/Widget\\" | ({
-        \\"@type\\": \\"Thing\\";
-    } & ThingBase);
+    export type Thing = \\"http://schema.org/Gadget\\" | \\"http://schema.org/Widget\\" | (ThingLeaf);
     export const Thing = {
         /** Complex! */
         Gadget: (\\"http://schema.org/Gadget\\" as const),

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -89,7 +89,7 @@ test(`baseine_${basename(__filename)}`, async () => {
      * - Bar
      * - _Baz_, and __Bat__
      */
-    export type Thing = \\"http://schema.org/Gadget\\" | \\"http://schema.org/Widget\\" | (ThingLeaf);
+    export type Thing = \\"http://schema.org/Gadget\\" | \\"http://schema.org/Widget\\" | ThingLeaf;
     export const Thing = {
         /** Complex! */
         Gadget: (\\"http://schema.org/Gadget\\" as const),

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -77,7 +77,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     /** A Thing! */
-    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | (ThingLeaf);
+    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | ThingLeaf;
     export const Thing = {
         a: (\\"http://schema.org/a\\" as const),
         b: (\\"http://schema.org/b\\" as const),

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -73,10 +73,11 @@ test(`baseine_${basename(__filename)}`, async () => {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
     };
-    /** A Thing! */
-    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase);
+    } & ThingBase;
+    /** A Thing! */
+    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | (ThingLeaf);
     export const Thing = {
         a: (\\"http://schema.org/a\\" as const),
         b: (\\"http://schema.org/b\\" as const),

--- a/test/baselines/inheritance_multiple_test.ts
+++ b/test/baselines/inheritance_multiple_test.ts
@@ -78,25 +78,28 @@ test(`baseine_${basename(__filename)}`, async () => {
     type PersonLikeBase = ThingBase & {
         \\"height\\"?: Number | readonly Number[];
     };
-    export type PersonLike = {
+    type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
     } & PersonLikeBase;
+    export type PersonLike = PersonLikeLeaf;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
         \\"name\\"?: Text | readonly Text[];
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | (PersonLike | Vehicle);
+    } & ThingBase;
+    export type Thing = ThingLeaf | (PersonLike | Vehicle);
 
     type VehicleBase = ThingBase & {
         \\"doors\\"?: Number | readonly Number[];
     };
-    export type Vehicle = {
+    type VehicleLeaf = {
         \\"@type\\": \\"Vehicle\\";
     } & VehicleBase;
+    export type Vehicle = VehicleLeaf;
 
     "
   `);

--- a/test/baselines/inheritance_multiple_test.ts
+++ b/test/baselines/inheritance_multiple_test.ts
@@ -91,7 +91,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
-    export type Thing = ThingLeaf | (PersonLike | Vehicle);
+    export type Thing = ThingLeaf | PersonLike | Vehicle;
 
     type VehicleBase = ThingBase & {
         \\"doors\\"?: Number | readonly Number[];

--- a/test/baselines/inheritance_one_test.ts
+++ b/test/baselines/inheritance_one_test.ts
@@ -73,18 +73,20 @@ test(`baseine_${basename(__filename)}`, async () => {
     type PersonLikeBase = ThingBase & {
         \\"height\\"?: Number | readonly Number[];
     };
-    export type PersonLike = {
+    type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
     } & PersonLikeBase;
+    export type PersonLike = PersonLikeLeaf;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
         \\"name\\"?: Text | readonly Text[];
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | PersonLike;
+    } & ThingBase;
+    export type Thing = ThingLeaf | PersonLike;
 
     "
   `);

--- a/test/baselines/nodeprecated_objects_test.ts
+++ b/test/baselines/nodeprecated_objects_test.ts
@@ -96,25 +96,28 @@ test(`baseine_${basename(__filename)}`, async () => {
     type CarBase = ThingBase & {
         \\"doorNumber\\"?: Number | readonly Number[];
     };
-    export type Car = {
+    type CarLeaf = {
         \\"@type\\": \\"Car\\";
     } & CarBase;
+    export type Car = CarLeaf;
 
     type PersonLikeBase = ThingBase & {
         \\"height\\"?: Number | readonly Number[];
     };
-    export type PersonLike = {
+    type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
     } & PersonLikeBase;
+    export type PersonLike = PersonLikeLeaf;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
         \\"name\\"?: Text | readonly Text[];
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | (Car | PersonLike);
+    } & ThingBase;
+    export type Thing = ThingLeaf | (Car | PersonLike);
 
     "
   `);

--- a/test/baselines/nodeprecated_objects_test.ts
+++ b/test/baselines/nodeprecated_objects_test.ts
@@ -117,7 +117,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
-    export type Thing = ThingLeaf | (Car | PersonLike);
+    export type Thing = ThingLeaf | Car | PersonLike;
 
     "
   `);

--- a/test/baselines/property_edge_cases_test.ts
+++ b/test/baselines/property_edge_cases_test.ts
@@ -74,9 +74,10 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"knows\\"?: never | readonly never[];
         \\"name\\"?: Text | readonly Text[];
     };
-    export type Thing = {
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
+    export type Thing = ThingLeaf;
 
     "
   `);

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -80,43 +80,50 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type DistanceBase = QuantityBase;
-    export type Distance = ({
+    type DistanceLeaf = {
         \\"@type\\": \\"Distance\\";
-    } & DistanceBase) | string;
+    } & DistanceBase;
+    export type Distance = DistanceLeaf | string;
 
     type DurationBase = QuantityBase;
-    export type Duration = ({
+    type DurationLeaf = {
         \\"@type\\": \\"Duration\\";
-    } & DurationBase) | string;
+    } & DurationBase;
+    export type Duration = DurationLeaf | string;
 
     type EnergyBase = QuantityBase;
-    export type Energy = ({
+    type EnergyLeaf = {
         \\"@type\\": \\"Energy\\";
-    } & EnergyBase) | string;
+    } & EnergyBase;
+    export type Energy = EnergyLeaf | string;
 
     type IntangibleBase = ThingBase;
-    export type Intangible = ({
+    type IntangibleLeaf = {
         \\"@type\\": \\"Intangible\\";
-    } & IntangibleBase) | Quantity;
+    } & IntangibleBase;
+    export type Intangible = IntangibleLeaf | Quantity;
 
     type MassBase = QuantityBase;
-    export type Mass = ({
+    type MassLeaf = {
         \\"@type\\": \\"Mass\\";
-    } & MassBase) | string;
+    } & MassBase;
+    export type Mass = MassLeaf | string;
 
     type QuantityBase = IntangibleBase;
-    export type Quantity = ({
+    type QuantityLeaf = {
         \\"@type\\": \\"Quantity\\";
-    } & QuantityBase) | (Distance | Duration | Energy | Mass | string);
+    } & QuantityBase;
+    export type Quantity = QuantityLeaf | (Distance | Duration | Energy | Mass | string);
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
         \\"name\\"?: Text | readonly Text[];
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | Intangible;
+    } & ThingBase;
+    export type Thing = ThingLeaf | Intangible;
 
     "
   `);

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -113,7 +113,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type QuantityLeaf = {
         \\"@type\\": \\"Quantity\\";
     } & QuantityBase;
-    export type Quantity = QuantityLeaf | (Distance | Duration | Energy | Mass | string);
+    export type Quantity = QuantityLeaf | Distance | Duration | Energy | Mass | string;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */

--- a/test/baselines/simple_test.ts
+++ b/test/baselines/simple_test.ts
@@ -70,9 +70,10 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\"?: string;
         \\"name\\"?: Text | readonly Text[];
     };
-    export type Thing = {
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
+    export type Thing = ThingLeaf;
 
     "
   `);

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -76,7 +76,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     /** A Thing! */
-    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | (ThingLeaf);
+    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | ThingLeaf;
     export const Thing = {
         a: (\\"http://schema.org/a\\" as const),
         b: (\\"http://schema.org/b\\" as const),

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -72,10 +72,11 @@ test(`baseine_${basename(__filename)}`, async () => {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
     };
-    /** A Thing! */
-    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase);
+    } & ThingBase;
+    /** A Thing! */
+    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | (ThingLeaf);
     export const Thing = {
         a: (\\"http://schema.org/a\\" as const),
         b: (\\"http://schema.org/b\\" as const),

--- a/test/baselines/sorted_props_test.ts
+++ b/test/baselines/sorted_props_test.ts
@@ -82,9 +82,10 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"c\\"?: Text | readonly Text[];
         \\"d\\"?: Text | readonly Text[];
     };
-    export type Thing = {
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
+    export type Thing = ThingLeaf;
 
     "
   `);

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -75,9 +75,10 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\"?: string;
         \\"a\\"?: (Boolean | Date | DateTime | Number | Text | Time) | readonly (Boolean | Date | DateTime | Number | Text | Time)[];
     };
-    export type Thing = {
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
+    export type Thing = ThingLeaf;
 
     "
   `);

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -89,45 +89,51 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type EntryPointBase = ThingBase;
-    export type EntryPoint = ({
+    type EntryPointLeaf = {
         \\"@type\\": \\"EntryPoint\\";
-    } & EntryPointBase) | string;
+    } & EntryPointBase;
+    export type EntryPoint = EntryPointLeaf | string;
 
     type OrganizationBase = ThingBase & {
         \\"locatedIn\\"?: Place | readonly Place[];
         \\"owner\\"?: Person | readonly Person[];
         \\"urlTemplate\\"?: URL | readonly URL[];
     };
-    export type Organization = ({
+    type OrganizationLeaf = {
         \\"@type\\": \\"Organization\\";
-    } & OrganizationBase) | string;
+    } & OrganizationBase;
+    export type Organization = OrganizationLeaf | string;
 
     type PersonBase = ThingBase & {
         \\"height\\"?: Quantity | readonly Quantity[];
         \\"locatedIn\\"?: Place | readonly Place[];
     };
-    export type Person = ({
+    type PersonLeaf = {
         \\"@type\\": \\"Person\\";
-    } & PersonBase) | string;
+    } & PersonBase;
+    export type Person = PersonLeaf | string;
 
     type PlaceBase = ThingBase;
-    export type Place = ({
+    type PlaceLeaf = {
         \\"@type\\": \\"Place\\";
-    } & PlaceBase) | string;
+    } & PlaceBase;
+    export type Place = PlaceLeaf | string;
 
     type QuantityBase = ThingBase;
-    export type Quantity = ({
+    type QuantityLeaf = {
         \\"@type\\": \\"Quantity\\";
-    } & QuantityBase) | string;
+    } & QuantityBase;
+    export type Quantity = QuantityLeaf | string;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
         \\"name\\"?: Text | readonly Text[];
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | (EntryPoint | Organization | Person | Place | Quantity);
+    } & ThingBase;
+    export type Thing = ThingLeaf | (EntryPoint | Organization | Person | Place | Quantity);
 
     "
   `);

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -133,7 +133,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
-    export type Thing = ThingLeaf | (EntryPoint | Organization | Person | Place | Quantity);
+    export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 
     "
   `);

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -89,45 +89,51 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type EntryPointBase = ThingBase;
-    export type EntryPoint = ({
+    type EntryPointLeaf = {
         \\"@type\\": \\"EntryPoint\\";
-    } & EntryPointBase) | string;
+    } & EntryPointBase;
+    export type EntryPoint = EntryPointLeaf | string;
 
     type OrganizationBase = ThingBase & {
         \\"locatedIn\\"?: Place | readonly Place[];
         \\"owner\\"?: Person | readonly Person[];
         \\"urlTemplate\\"?: URL | readonly URL[];
     };
-    export type Organization = ({
+    type OrganizationLeaf = {
         \\"@type\\": \\"Organization\\";
-    } & OrganizationBase) | string;
+    } & OrganizationBase;
+    export type Organization = OrganizationLeaf | string;
 
     type PersonBase = ThingBase & {
         \\"height\\"?: Quantity | readonly Quantity[];
         \\"locatedIn\\"?: Place | readonly Place[];
     };
-    export type Person = ({
+    type PersonLeaf = {
         \\"@type\\": \\"Person\\";
-    } & PersonBase) | string;
+    } & PersonBase;
+    export type Person = PersonLeaf | string;
 
     type PlaceBase = ThingBase;
-    export type Place = ({
+    type PlaceLeaf = {
         \\"@type\\": \\"Place\\";
-    } & PlaceBase) | string;
+    } & PlaceBase;
+    export type Place = PlaceLeaf | string;
 
     type QuantityBase = ThingBase;
-    export type Quantity = ({
+    type QuantityLeaf = {
         \\"@type\\": \\"Quantity\\";
-    } & QuantityBase) | string;
+    } & QuantityBase;
+    export type Quantity = QuantityLeaf | string;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
         \\"name\\"?: Text | readonly Text[];
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | (EntryPoint | Organization | Person | Place | Quantity);
+    } & ThingBase;
+    export type Thing = ThingLeaf | (EntryPoint | Organization | Person | Place | Quantity);
 
     "
   `);

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -133,7 +133,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
-    export type Thing = ThingLeaf | (EntryPoint | Organization | Person | Place | Quantity);
+    export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 
     "
   `);

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -82,47 +82,54 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type EnumerationBase = IntangibleBase;
-    export type Enumeration = ({
+    type EnumerationLeaf = {
         \\"@type\\": \\"Enumeration\\";
-    } & EnumerationBase) | MedicalEnumeration;
+    } & EnumerationBase;
+    export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
     type IntangibleBase = ThingBase;
-    export type Intangible = ({
+    type IntangibleLeaf = {
         \\"@type\\": \\"Intangible\\";
-    } & IntangibleBase) | Enumeration;
+    } & IntangibleBase;
+    export type Intangible = IntangibleLeaf | Enumeration;
 
     type MedicalEnumerationBase = EnumerationBase;
-    export type MedicalEnumeration = ({
+    type MedicalEnumerationLeaf = {
         \\"@type\\": \\"MedicalEnumeration\\";
-    } & MedicalEnumerationBase) | MedicalProcedureType;
+    } & MedicalEnumerationBase;
+    export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
     type MedicalProcedureBase = ThingBase;
-    export type MedicalProcedure = ({
+    type MedicalProcedureLeaf = {
         \\"@type\\": \\"MedicalProcedure\\";
-    } & MedicalProcedureBase) | SurgicalProcedure;
+    } & MedicalProcedureBase;
+    export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
     type MedicalProcedureTypeBase = MedicalEnumerationBase;
-    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | ({
+    type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
-    } & MedicalProcedureTypeBase);
+    } & MedicalProcedureTypeBase;
+    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | (MedicalProcedureTypeLeaf);
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
     };
 
     type SurgicalProcedureBase = MedicalProcedureBase;
-    /** A type of medical procedure that involves invasive surgical techniques. */
-    export type SurgicalProcedure = {
+    type SurgicalProcedureLeaf = {
         \\"@type\\": \\"SurgicalProcedure\\";
     } & SurgicalProcedureBase;
+    /** A type of medical procedure that involves invasive surgical techniques. */
+    export type SurgicalProcedure = SurgicalProcedureLeaf;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | (Intangible | MedicalProcedure);
+    } & ThingBase;
+    export type Thing = ThingLeaf | (Intangible | MedicalProcedure);
 
     "
   `);

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -109,7 +109,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & MedicalProcedureTypeBase;
-    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | (MedicalProcedureTypeLeaf);
+    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
@@ -129,7 +129,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
-    export type Thing = ThingLeaf | (Intangible | MedicalProcedure);
+    export type Thing = ThingLeaf | Intangible | MedicalProcedure;
 
     "
   `);

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -82,47 +82,54 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type EnumerationBase = IntangibleBase;
-    export type Enumeration = ({
+    type EnumerationLeaf = {
         \\"@type\\": \\"Enumeration\\";
-    } & EnumerationBase) | MedicalEnumeration;
+    } & EnumerationBase;
+    export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
     type IntangibleBase = ThingBase;
-    export type Intangible = ({
+    type IntangibleLeaf = {
         \\"@type\\": \\"Intangible\\";
-    } & IntangibleBase) | Enumeration;
+    } & IntangibleBase;
+    export type Intangible = IntangibleLeaf | Enumeration;
 
     type MedicalEnumerationBase = EnumerationBase;
-    export type MedicalEnumeration = ({
+    type MedicalEnumerationLeaf = {
         \\"@type\\": \\"MedicalEnumeration\\";
-    } & MedicalEnumerationBase) | MedicalProcedureType;
+    } & MedicalEnumerationBase;
+    export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
     type MedicalProcedureBase = ThingBase;
-    export type MedicalProcedure = ({
+    type MedicalProcedureLeaf = {
         \\"@type\\": \\"MedicalProcedure\\";
-    } & MedicalProcedureBase) | SurgicalProcedure;
+    } & MedicalProcedureBase;
+    export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
     type MedicalProcedureTypeBase = MedicalEnumerationBase;
-    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | ({
+    type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
-    } & MedicalProcedureTypeBase);
+    } & MedicalProcedureTypeBase;
+    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | (MedicalProcedureTypeLeaf);
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
     };
 
     type SurgicalProcedureBase = MedicalProcedureBase;
-    /** A type of medical procedure that involves invasive surgical techniques. */
-    export type SurgicalProcedure = {
+    type SurgicalProcedureLeaf = {
         \\"@type\\": \\"SurgicalProcedure\\";
     } & SurgicalProcedureBase;
+    /** A type of medical procedure that involves invasive surgical techniques. */
+    export type SurgicalProcedure = SurgicalProcedureLeaf;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | (Intangible | MedicalProcedure);
+    } & ThingBase;
+    export type Thing = ThingLeaf | (Intangible | MedicalProcedure);
 
     "
   `);

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -109,7 +109,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & MedicalProcedureTypeBase;
-    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | (MedicalProcedureTypeLeaf);
+    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
@@ -129,7 +129,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
-    export type Thing = ThingLeaf | (Intangible | MedicalProcedure);
+    export type Thing = ThingLeaf | Intangible | MedicalProcedure;
 
     "
   `);

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -134,21 +134,21 @@ test(`baseine_${basename(__filename)}`, async () => {
     type MedicalEnumerationLeaf = {
         \\"@type\\": \\"MedicalEnumeration\\";
     } & MedicalEnumerationBase;
-    export type MedicalEnumeration = MedicalEnumerationLeaf | (MedicalProcedureType | PhysicalExam);
+    export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType | PhysicalExam;
 
     type MedicalProcedureBase = MedicalEntityBase;
     type MedicalProcedureLeaf = {
         \\"@type\\": \\"MedicalProcedure\\";
     } & MedicalProcedureBase;
     /** A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques. */
-    export type MedicalProcedure = MedicalProcedureLeaf | (DiagnosticProcedure | PalliativeProcedure | PhysicalExam | SurgicalProcedure | TherapeuticProcedure);
+    export type MedicalProcedure = MedicalProcedureLeaf | DiagnosticProcedure | PalliativeProcedure | PhysicalExam | SurgicalProcedure | TherapeuticProcedure;
 
     type MedicalProcedureTypeBase = MedicalEnumerationBase;
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & MedicalProcedureTypeBase;
     /** An enumeration that describes different types of medical procedures. */
-    export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | (MedicalProcedureTypeLeaf);
+    export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         NoninvasiveProcedure: (\\"http://schema.org/NoninvasiveProcedure\\" as const),
         PercutaneousProcedure: (\\"http://schema.org/PercutaneousProcedure\\" as const)
@@ -170,7 +170,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type PhysicalExamLeaf = {
         \\"@type\\": \\"PhysicalExam\\";
     } & PhysicalExamBase;
-    export type PhysicalExam = \\"http://schema.org/Head\\" | \\"http://schema.org/Neuro\\" | (PhysicalExamLeaf);
+    export type PhysicalExam = \\"http://schema.org/Head\\" | \\"http://schema.org/Neuro\\" | PhysicalExamLeaf;
     export const PhysicalExam = {
         Head: (\\"http://schema.org/Head\\" as const),
         Neuro: (\\"http://schema.org/Neuro\\" as const)
@@ -197,7 +197,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
-    export type Thing = ThingLeaf | (Intangible | MedicalEntity);
+    export type Thing = ThingLeaf | Intangible | MedicalEntity;
 
     "
   `);

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -107,84 +107,97 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type DiagnosticProcedureBase = MedicalProcedureBase;
-    export type DiagnosticProcedure = {
+    type DiagnosticProcedureLeaf = {
         \\"@type\\": \\"DiagnosticProcedure\\";
     } & DiagnosticProcedureBase;
+    export type DiagnosticProcedure = DiagnosticProcedureLeaf;
 
     type EnumerationBase = IntangibleBase;
-    export type Enumeration = ({
+    type EnumerationLeaf = {
         \\"@type\\": \\"Enumeration\\";
-    } & EnumerationBase) | MedicalEnumeration;
+    } & EnumerationBase;
+    export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
     type IntangibleBase = ThingBase;
-    export type Intangible = ({
+    type IntangibleLeaf = {
         \\"@type\\": \\"Intangible\\";
-    } & IntangibleBase) | Enumeration;
+    } & IntangibleBase;
+    export type Intangible = IntangibleLeaf | Enumeration;
 
     type MedicalEntityBase = ThingBase;
-    export type MedicalEntity = ({
+    type MedicalEntityLeaf = {
         \\"@type\\": \\"MedicalEntity\\";
-    } & MedicalEntityBase) | MedicalProcedure;
+    } & MedicalEntityBase;
+    export type MedicalEntity = MedicalEntityLeaf | MedicalProcedure;
 
     type MedicalEnumerationBase = EnumerationBase;
-    export type MedicalEnumeration = ({
+    type MedicalEnumerationLeaf = {
         \\"@type\\": \\"MedicalEnumeration\\";
-    } & MedicalEnumerationBase) | (MedicalProcedureType | PhysicalExam);
+    } & MedicalEnumerationBase;
+    export type MedicalEnumeration = MedicalEnumerationLeaf | (MedicalProcedureType | PhysicalExam);
 
     type MedicalProcedureBase = MedicalEntityBase;
-    /** A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques. */
-    export type MedicalProcedure = ({
+    type MedicalProcedureLeaf = {
         \\"@type\\": \\"MedicalProcedure\\";
-    } & MedicalProcedureBase) | (DiagnosticProcedure | PalliativeProcedure | PhysicalExam | SurgicalProcedure | TherapeuticProcedure);
+    } & MedicalProcedureBase;
+    /** A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques. */
+    export type MedicalProcedure = MedicalProcedureLeaf | (DiagnosticProcedure | PalliativeProcedure | PhysicalExam | SurgicalProcedure | TherapeuticProcedure);
 
     type MedicalProcedureTypeBase = MedicalEnumerationBase;
-    /** An enumeration that describes different types of medical procedures. */
-    export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | ({
+    type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
-    } & MedicalProcedureTypeBase);
+    } & MedicalProcedureTypeBase;
+    /** An enumeration that describes different types of medical procedures. */
+    export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | (MedicalProcedureTypeLeaf);
     export const MedicalProcedureType = {
         NoninvasiveProcedure: (\\"http://schema.org/NoninvasiveProcedure\\" as const),
         PercutaneousProcedure: (\\"http://schema.org/PercutaneousProcedure\\" as const)
     };
 
     type MedicalTherapyBase = TherapeuticProcedureBase;
-    export type MedicalTherapy = ({
+    type MedicalTherapyLeaf = {
         \\"@type\\": \\"MedicalTherapy\\";
-    } & MedicalTherapyBase) | PalliativeProcedure;
+    } & MedicalTherapyBase;
+    export type MedicalTherapy = MedicalTherapyLeaf | PalliativeProcedure;
 
     type PalliativeProcedureBase = (MedicalProcedureBase & MedicalTherapyBase);
-    export type PalliativeProcedure = {
+    type PalliativeProcedureLeaf = {
         \\"@type\\": \\"PalliativeProcedure\\";
     } & PalliativeProcedureBase;
+    export type PalliativeProcedure = PalliativeProcedureLeaf;
 
     type PhysicalExamBase = (MedicalProcedureBase & MedicalEnumerationBase);
-    export type PhysicalExam = \\"http://schema.org/Head\\" | \\"http://schema.org/Neuro\\" | ({
+    type PhysicalExamLeaf = {
         \\"@type\\": \\"PhysicalExam\\";
-    } & PhysicalExamBase);
+    } & PhysicalExamBase;
+    export type PhysicalExam = \\"http://schema.org/Head\\" | \\"http://schema.org/Neuro\\" | (PhysicalExamLeaf);
     export const PhysicalExam = {
         Head: (\\"http://schema.org/Head\\" as const),
         Neuro: (\\"http://schema.org/Neuro\\" as const)
     };
 
     type SurgicalProcedureBase = MedicalProcedureBase;
-    /** A medical procedure involving an incision with instruments; performed for diagnose, or therapeutic purposes. */
-    export type SurgicalProcedure = {
+    type SurgicalProcedureLeaf = {
         \\"@type\\": \\"SurgicalProcedure\\";
     } & SurgicalProcedureBase;
+    /** A medical procedure involving an incision with instruments; performed for diagnose, or therapeutic purposes. */
+    export type SurgicalProcedure = SurgicalProcedureLeaf;
 
     type TherapeuticProcedureBase = MedicalProcedureBase;
-    export type TherapeuticProcedure = ({
+    type TherapeuticProcedureLeaf = {
         \\"@type\\": \\"TherapeuticProcedure\\";
-    } & TherapeuticProcedureBase) | MedicalTherapy;
+    } & TherapeuticProcedureBase;
+    export type TherapeuticProcedure = TherapeuticProcedureLeaf | MedicalTherapy;
 
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
         \\"procedureType\\"?: MedicalProcedureType | readonly MedicalProcedureType[];
     };
-    export type Thing = ({
+    type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase) | (Intangible | MedicalEntity);
+    } & ThingBase;
+    export type Thing = ThingLeaf | (Intangible | MedicalEntity);
 
     "
   `);

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -75,15 +75,16 @@ describe('Class', () => {
       // A class with no parent has a top-level "@id"
       const ctx = new Context();
       ctx.setUrlContext('https://schema.org/');
-      expect(asString(cls, ctx)).toBe(
-        'type PersonBase = {\n' +
-          '    /** IRI identifying the canonical address of this object. */\n' +
-          '    "@id"?: string;\n' +
-          '};\n' +
-          'export type Person = {\n' +
-          '    "@type": "Person";\n' +
-          '} & PersonBase;'
-      );
+      expect(asString(cls, ctx)).toMatchInlineSnapshot(`
+        "type PersonBase = {
+            /** IRI identifying the canonical address of this object. */
+            \\"@id\\"?: string;
+        };
+        type PersonLeaf = {
+            \\"@type\\": \\"Person\\";
+        } & PersonBase;
+        export type Person = PersonLeaf;"
+      `);
     });
 
     it('empty (with parent)', () => {
@@ -91,12 +92,13 @@ describe('Class', () => {
       ctx.setUrlContext('https://schema.org/');
       addParent(cls, 'https://schema.org/Thing');
 
-      expect(asString(cls, ctx)).toBe(
-        'type PersonBase = ThingBase;\n' +
-          'export type Person = {\n' +
-          '    "@type": "Person";\n' +
-          '} & PersonBase;'
-      );
+      expect(asString(cls, ctx)).toMatchInlineSnapshot(`
+        "type PersonBase = ThingBase;
+        type PersonLeaf = {
+            \\"@type\\": \\"Person\\";
+        } & PersonBase;
+        export type Person = PersonLeaf;"
+      `);
     });
 
     it('deprecated once (only)', () => {
@@ -114,13 +116,14 @@ describe('Class', () => {
         )
       ).toBe(true);
 
-      expect(asString(cls, ctx)).toBe(
-        'type PersonBase = ThingBase;\n' +
-          '/** @deprecated Use CoolPerson instead. */\n' +
-          'export type Person = {\n' +
-          '    "@type": "Person";\n' +
-          '} & PersonBase;'
-      );
+      expect(asString(cls, ctx)).toMatchInlineSnapshot(`
+        "type PersonBase = ThingBase;
+        type PersonLeaf = {
+            \\"@type\\": \\"Person\\";
+        } & PersonBase;
+        /** @deprecated Use CoolPerson instead. */
+        export type Person = PersonLeaf;"
+      `);
     });
 
     it('deprecated twice (alphabetical)', () => {
@@ -154,13 +157,14 @@ describe('Class', () => {
         )
       ).toBe(true);
 
-      expect(asString(cls, ctx)).toBe(
-        'type PersonBase = ThingBase;\n' +
-          '/** @deprecated Use APerson or CoolPerson instead. */\n' +
-          'export type Person = {\n' +
-          '    "@type": "Person";\n' +
-          '} & PersonBase;'
-      );
+      expect(asString(cls, ctx)).toMatchInlineSnapshot(`
+        "type PersonBase = ThingBase;
+        type PersonLeaf = {
+            \\"@type\\": \\"Person\\";
+        } & PersonBase;
+        /** @deprecated Use APerson or CoolPerson instead. */
+        export type Person = PersonLeaf;"
+      `);
     });
 
     it('deprecated with comment', () => {
@@ -187,16 +191,17 @@ describe('Class', () => {
         )
       ).toBe(true);
 
-      expect(asString(cls, ctx)).toBe(
-        'type PersonBase = ThingBase;\n' +
-          '/**\n' +
-          ' * Fantastic\n' +
-          ' * @deprecated Use CoolPerson instead.\n' +
-          ' */\n' +
-          'export type Person = {\n' +
-          '    "@type": "Person";\n' +
-          '} & PersonBase;'
-      );
+      expect(asString(cls, ctx)).toMatchInlineSnapshot(`
+        "type PersonBase = ThingBase;
+        type PersonLeaf = {
+            \\"@type\\": \\"Person\\";
+        } & PersonBase;
+        /**
+         * Fantastic
+         * @deprecated Use CoolPerson instead.
+         */
+        export type Person = PersonLeaf;"
+      `);
     });
 
     it('complains about bad comment markup', () => {


### PR DESCRIPTION
Rather than inlining a "leaf" type as an intersection in a big union,
name it. This should hopefully help with #34.

This is based on advice from @amcasey regarding compiler performance:

> I've definitely seen some impressive perf improvements from naming
> intermediate types (because it can short-circuit structural type
> comparison, which is very expensive).

This fits neatly with my initial description of the Schema.org type
system here:
https://blog.eyas.sh/2019/05/modeling-schema-org-schema-with-typescript-the-power-and-limitations-of-the-typescript-type-system/

There's still some room for improvements:

- Some intermediate types are simply aliases, can we remove these?
- 'DataType's don't necessarily fit neatly here.

Also in this PR,
- Remove unnecessary parens from certain type unions.