### PR TITLE
Bump to version 0.5.3

### DIFF
--- a/dist/schema/package.json
+++ b/dist/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "displayName": "schema-dts: Strongly-typed Schema.org vocabulary declarations",
   "description": "A TypeScript package with latest Schema.org Schema Typings",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts-gen",
-  "version": "0.5.1",
+  "version": "0.5.3",
   "displayName": "schema-dts Generator",
   "description": "Generate TypeScript Definitions for Schema.org Schema",
   "authors": [


### PR DESCRIPTION
We'll release both:
- schema-dts-gen@0.5.3, picking up intermediate types.
- schema-dts@0.5.3, picking up above, plus v8.0