### PR TITLE
Cleaner output .d.ts

### DIFF
--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -31,6 +31,7 @@ import {Context} from '../ts/context';
 import {ProcessClasses} from './toClass';
 import {ProcessEnums} from './toEnum';
 import {ProcessProperties} from './toProperty';
+import {HelperTypes} from '../ts/helper_types';
 
 /**
  * Writes TypeScript declarations for all Classes, Typedefs, and Enums
@@ -69,6 +70,12 @@ export async function WriteDeclarations(
 
   write(printer.printNode(EmitHint.Unspecified, context.toNode(), source));
   write('\n\n');
+
+  for (const helperType of HelperTypes()) {
+    write(printer.printNode(EmitHint.Unspecified, helperType, source));
+    write('\n');
+  }
+  write('\n');
 
   for (const cls of sorted) {
     if (cls.deprecated && !includeDeprecated) continue;

--- a/src/ts/helper_types.ts
+++ b/src/ts/helper_types.ts
@@ -1,0 +1,32 @@
+import {
+  createTypeAliasDeclaration,
+  createIdentifier,
+  createTypeParameterDeclaration,
+  createUnionTypeNode,
+  createTypeReferenceNode,
+  createTypeOperatorNode,
+  createArrayTypeNode,
+  SyntaxKind,
+} from 'typescript';
+
+export const SchemaValueName = 'SchemaValue';
+
+export function HelperTypes() {
+  return [
+    createTypeAliasDeclaration(
+      undefined,
+      undefined,
+      createIdentifier(SchemaValueName),
+      [createTypeParameterDeclaration(createIdentifier('T'))],
+      createUnionTypeNode([
+        createTypeReferenceNode(createIdentifier('T'), undefined),
+        createTypeOperatorNode(
+          SyntaxKind.ReadonlyKeyword,
+          createArrayTypeNode(
+            createTypeReferenceNode(createIdentifier('T'), undefined)
+          )
+        ),
+      ])
+    ),
+  ];
+}

--- a/src/ts/property.ts
+++ b/src/ts/property.ts
@@ -15,16 +15,15 @@
  */
 
 import {
-  createArrayTypeNode,
   createKeywordTypeNode,
   createPropertySignature,
   createStringLiteral,
   createToken,
-  createTypeOperatorNode,
   createTypeReferenceNode,
   createUnionTypeNode,
   PropertySignature,
   SyntaxKind,
+  createIdentifier,
 } from 'typescript';
 
 import {Log} from '../logging';
@@ -42,6 +41,7 @@ import {ClassMap} from './class';
 import {Context} from './context';
 import {withComments} from './util/comments';
 import {toClassName} from './util/names';
+import {SchemaValueName} from './helper_types';
 
 /**
  * A "class" of properties, not associated with any particuar object.
@@ -135,14 +135,10 @@ export class Property {
   }
 
   private typeNode() {
-    const node = this.type.scalarTypeNode();
-    return createUnionTypeNode([
-      node,
-      createTypeOperatorNode(
-        SyntaxKind.ReadonlyKeyword,
-        createArrayTypeNode(node)
-      ),
-    ]);
+    return createTypeReferenceNode(
+      createIdentifier(SchemaValueName),
+      /* typeArguments = */ [this.type.scalarTypeNode()]
+    );
   }
 
   toNode(context: Context): PropertySignature {

--- a/test/baselines/category_test.ts
+++ b/test/baselines/category_test.ts
@@ -71,10 +71,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type DistilleryBase = ThingBase;
     type DistilleryLeaf = {
         \\"@type\\": \\"Distillery\\";
-    } & DistilleryBase;
+    } & ThingBase;
     /** A distillery. */
     export type Distillery = DistilleryLeaf;
 

--- a/test/baselines/category_test.ts
+++ b/test/baselines/category_test.ts
@@ -44,6 +44,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -79,7 +81,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/comments_test.ts
+++ b/test/baselines/comments_test.ts
@@ -44,6 +44,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -78,9 +80,9 @@ test(`baseine_${basename(__filename)}`, async () => {
          *
          * \`Hey!\` this.
          */
-        \\"knows\\"?: Text | readonly Text[];
+        \\"knows\\"?: SchemaValue<Text>;
         /** Names are great! {@link X Y} */
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/default_ontology_test.ts
+++ b/test/baselines/default_ontology_test.ts
@@ -35,6 +35,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {

--- a/test/baselines/deprecated_objects_test.ts
+++ b/test/baselines/deprecated_objects_test.ts
@@ -62,6 +62,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -88,7 +90,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type CarBase = ThingBase & {
-        \\"doorNumber\\"?: Number | readonly Number[];
+        \\"doorNumber\\"?: SchemaValue<Number>;
     };
     type CarLeaf = {
         \\"@type\\": \\"Car\\";
@@ -96,7 +98,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type Car = CarLeaf;
 
     type PersonLikeBase = ThingBase & {
-        \\"height\\"?: Number | readonly Number[];
+        \\"height\\"?: SchemaValue<Number>;
     };
     type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
@@ -106,12 +108,12 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
         /**
          * Names are great! {@link X Y}
          * @deprecated Consider using http://schema.org/name or http://schema.org/height instead.
          */
-        \\"names\\"?: Text | readonly Text[];
+        \\"names\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
@@ -119,9 +121,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type Thing = ThingLeaf | Car | PersonLike | Vehicle;
 
     type VehicleBase = ThingBase & {
-        \\"doorNumber\\"?: Number | readonly Number[];
+        \\"doorNumber\\"?: SchemaValue<Number>;
         /** @deprecated Consider using http://schema.org/doorNumber instead. */
-        \\"doors\\"?: Number | readonly Number[];
+        \\"doors\\"?: SchemaValue<Number>;
     };
     type VehicleLeaf = {
         \\"@type\\": \\"Vehicle\\";

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -46,6 +46,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -75,7 +77,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
         /** Names are great! {@link X Y} */
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -42,6 +42,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {

--- a/test/baselines/inheritance_multiple_test.ts
+++ b/test/baselines/inheritance_multiple_test.ts
@@ -48,6 +48,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -74,7 +76,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type PersonLikeBase = ThingBase & {
-        \\"height\\"?: Number | readonly Number[];
+        \\"height\\"?: SchemaValue<Number>;
     };
     type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
@@ -84,7 +86,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
@@ -92,7 +94,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type Thing = ThingLeaf | PersonLike | Vehicle;
 
     type VehicleBase = ThingBase & {
-        \\"doors\\"?: Number | readonly Number[];
+        \\"doors\\"?: SchemaValue<Number>;
     };
     type VehicleLeaf = {
         \\"@type\\": \\"Vehicle\\";

--- a/test/baselines/inheritance_one_test.ts
+++ b/test/baselines/inheritance_one_test.ts
@@ -43,6 +43,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -69,7 +71,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type PersonLikeBase = ThingBase & {
-        \\"height\\"?: Number | readonly Number[];
+        \\"height\\"?: SchemaValue<Number>;
     };
     type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
@@ -79,7 +81,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/nodeprecated_objects_test.ts
+++ b/test/baselines/nodeprecated_objects_test.ts
@@ -66,6 +66,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -92,7 +94,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type CarBase = ThingBase & {
-        \\"doorNumber\\"?: Number | readonly Number[];
+        \\"doorNumber\\"?: SchemaValue<Number>;
     };
     type CarLeaf = {
         \\"@type\\": \\"Car\\";
@@ -100,7 +102,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type Car = CarLeaf;
 
     type PersonLikeBase = ThingBase & {
-        \\"height\\"?: Number | readonly Number[];
+        \\"height\\"?: SchemaValue<Number>;
     };
     type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
@@ -110,7 +112,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/property_edge_cases_test.ts
+++ b/test/baselines/property_edge_cases_test.ts
@@ -41,6 +41,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -69,8 +71,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"knows\\"?: never | readonly never[];
-        \\"name\\"?: Text | readonly Text[];
+        \\"knows\\"?: SchemaValue<never>;
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -52,6 +52,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -116,7 +118,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -79,40 +79,34 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type DistanceBase = QuantityBase;
     type DistanceLeaf = {
         \\"@type\\": \\"Distance\\";
-    } & DistanceBase;
+    } & ThingBase;
     export type Distance = DistanceLeaf | string;
 
-    type DurationBase = QuantityBase;
     type DurationLeaf = {
         \\"@type\\": \\"Duration\\";
-    } & DurationBase;
+    } & ThingBase;
     export type Duration = DurationLeaf | string;
 
-    type EnergyBase = QuantityBase;
     type EnergyLeaf = {
         \\"@type\\": \\"Energy\\";
-    } & EnergyBase;
+    } & ThingBase;
     export type Energy = EnergyLeaf | string;
 
-    type IntangibleBase = ThingBase;
     type IntangibleLeaf = {
         \\"@type\\": \\"Intangible\\";
-    } & IntangibleBase;
+    } & ThingBase;
     export type Intangible = IntangibleLeaf | Quantity;
 
-    type MassBase = QuantityBase;
     type MassLeaf = {
         \\"@type\\": \\"Mass\\";
-    } & MassBase;
+    } & ThingBase;
     export type Mass = MassLeaf | string;
 
-    type QuantityBase = IntangibleBase;
     type QuantityLeaf = {
         \\"@type\\": \\"Quantity\\";
-    } & QuantityBase;
+    } & ThingBase;
     export type Quantity = QuantityLeaf | Distance | Duration | Energy | Mass | string;
 
     type ThingBase = {

--- a/test/baselines/simple_test.ts
+++ b/test/baselines/simple_test.ts
@@ -38,6 +38,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -66,7 +68,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -41,6 +41,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {

--- a/test/baselines/sorted_props_test.ts
+++ b/test/baselines/sorted_props_test.ts
@@ -47,6 +47,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -75,10 +77,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"a\\"?: Text | readonly Text[];
-        \\"b\\"?: Text | readonly Text[];
-        \\"c\\"?: Text | readonly Text[];
-        \\"d\\"?: Text | readonly Text[];
+        \\"a\\"?: SchemaValue<Text>;
+        \\"b\\"?: SchemaValue<Text>;
+        \\"c\\"?: SchemaValue<Text>;
+        \\"d\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -43,6 +43,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -71,7 +73,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"a\\"?: (Boolean | Date | DateTime | Number | Text | Time) | readonly (Boolean | Date | DateTime | Number | Text | Time)[];
+        \\"a\\"?: SchemaValue<Boolean | Date | DateTime | Number | Text | Time>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -61,6 +61,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -93,9 +95,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type EntryPoint = EntryPointLeaf | string;
 
     type OrganizationBase = ThingBase & {
-        \\"locatedIn\\"?: Place | readonly Place[];
-        \\"owner\\"?: Person | readonly Person[];
-        \\"urlTemplate\\"?: URL | readonly URL[];
+        \\"locatedIn\\"?: SchemaValue<Place>;
+        \\"owner\\"?: SchemaValue<Person>;
+        \\"urlTemplate\\"?: SchemaValue<URL>;
     };
     type OrganizationLeaf = {
         \\"@type\\": \\"Organization\\";
@@ -103,8 +105,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type Organization = OrganizationLeaf | string;
 
     type PersonBase = ThingBase & {
-        \\"height\\"?: Quantity | readonly Quantity[];
-        \\"locatedIn\\"?: Place | readonly Place[];
+        \\"height\\"?: SchemaValue<Quantity>;
+        \\"locatedIn\\"?: SchemaValue<Place>;
     };
     type PersonLeaf = {
         \\"@type\\": \\"Person\\";
@@ -126,7 +128,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -88,10 +88,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type EntryPointBase = ThingBase;
     type EntryPointLeaf = {
         \\"@type\\": \\"EntryPoint\\";
-    } & EntryPointBase;
+    } & ThingBase;
     export type EntryPoint = EntryPointLeaf | string;
 
     type OrganizationBase = ThingBase & {
@@ -113,16 +112,14 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & PersonBase;
     export type Person = PersonLeaf | string;
 
-    type PlaceBase = ThingBase;
     type PlaceLeaf = {
         \\"@type\\": \\"Place\\";
-    } & PlaceBase;
+    } & ThingBase;
     export type Place = PlaceLeaf | string;
 
-    type QuantityBase = ThingBase;
     type QuantityLeaf = {
         \\"@type\\": \\"Quantity\\";
-    } & QuantityBase;
+    } & ThingBase;
     export type Quantity = QuantityLeaf | string;
 
     type ThingBase = {

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -61,6 +61,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -93,9 +95,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type EntryPoint = EntryPointLeaf | string;
 
     type OrganizationBase = ThingBase & {
-        \\"locatedIn\\"?: Place | readonly Place[];
-        \\"owner\\"?: Person | readonly Person[];
-        \\"urlTemplate\\"?: URL | readonly URL[];
+        \\"locatedIn\\"?: SchemaValue<Place>;
+        \\"owner\\"?: SchemaValue<Person>;
+        \\"urlTemplate\\"?: SchemaValue<URL>;
     };
     type OrganizationLeaf = {
         \\"@type\\": \\"Organization\\";
@@ -103,8 +105,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type Organization = OrganizationLeaf | string;
 
     type PersonBase = ThingBase & {
-        \\"height\\"?: Quantity | readonly Quantity[];
-        \\"locatedIn\\"?: Place | readonly Place[];
+        \\"height\\"?: SchemaValue<Quantity>;
+        \\"locatedIn\\"?: SchemaValue<Place>;
     };
     type PersonLeaf = {
         \\"@type\\": \\"Person\\";
@@ -126,7 +128,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"name\\"?: Text | readonly Text[];
+        \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -88,10 +88,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type EntryPointBase = ThingBase;
     type EntryPointLeaf = {
         \\"@type\\": \\"EntryPoint\\";
-    } & EntryPointBase;
+    } & ThingBase;
     export type EntryPoint = EntryPointLeaf | string;
 
     type OrganizationBase = ThingBase & {
@@ -113,16 +112,14 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & PersonBase;
     export type Person = PersonLeaf | string;
 
-    type PlaceBase = ThingBase;
     type PlaceLeaf = {
         \\"@type\\": \\"Place\\";
-    } & PlaceBase;
+    } & ThingBase;
     export type Place = PlaceLeaf | string;
 
-    type QuantityBase = ThingBase;
     type QuantityLeaf = {
         \\"@type\\": \\"Quantity\\";
-    } & QuantityBase;
+    } & ThingBase;
     export type Quantity = QuantityLeaf | string;
 
     type ThingBase = {

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -81,44 +81,38 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type EnumerationBase = IntangibleBase;
     type EnumerationLeaf = {
         \\"@type\\": \\"Enumeration\\";
-    } & EnumerationBase;
+    } & ThingBase;
     export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
-    type IntangibleBase = ThingBase;
     type IntangibleLeaf = {
         \\"@type\\": \\"Intangible\\";
-    } & IntangibleBase;
+    } & ThingBase;
     export type Intangible = IntangibleLeaf | Enumeration;
 
-    type MedicalEnumerationBase = EnumerationBase;
     type MedicalEnumerationLeaf = {
         \\"@type\\": \\"MedicalEnumeration\\";
-    } & MedicalEnumerationBase;
+    } & ThingBase;
     export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
-    type MedicalProcedureBase = ThingBase;
     type MedicalProcedureLeaf = {
         \\"@type\\": \\"MedicalProcedure\\";
-    } & MedicalProcedureBase;
+    } & ThingBase;
     export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
-    type MedicalProcedureTypeBase = MedicalEnumerationBase;
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
-    } & MedicalProcedureTypeBase;
+    } & ThingBase;
     export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
     };
 
-    type SurgicalProcedureBase = MedicalProcedureBase;
     type SurgicalProcedureLeaf = {
         \\"@type\\": \\"SurgicalProcedure\\";
-    } & SurgicalProcedureBase;
+    } & ThingBase;
     /** A type of medical procedure that involves invasive surgical techniques. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -54,6 +54,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -81,44 +81,38 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type EnumerationBase = IntangibleBase;
     type EnumerationLeaf = {
         \\"@type\\": \\"Enumeration\\";
-    } & EnumerationBase;
+    } & ThingBase;
     export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
-    type IntangibleBase = ThingBase;
     type IntangibleLeaf = {
         \\"@type\\": \\"Intangible\\";
-    } & IntangibleBase;
+    } & ThingBase;
     export type Intangible = IntangibleLeaf | Enumeration;
 
-    type MedicalEnumerationBase = EnumerationBase;
     type MedicalEnumerationLeaf = {
         \\"@type\\": \\"MedicalEnumeration\\";
-    } & MedicalEnumerationBase;
+    } & ThingBase;
     export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
-    type MedicalProcedureBase = ThingBase;
     type MedicalProcedureLeaf = {
         \\"@type\\": \\"MedicalProcedure\\";
-    } & MedicalProcedureBase;
+    } & ThingBase;
     export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
-    type MedicalProcedureTypeBase = MedicalEnumerationBase;
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
-    } & MedicalProcedureTypeBase;
+    } & ThingBase;
     export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
     };
 
-    type SurgicalProcedureBase = MedicalProcedureBase;
     type SurgicalProcedureLeaf = {
         \\"@type\\": \\"SurgicalProcedure\\";
-    } & SurgicalProcedureBase;
+    } & ThingBase;
     /** A type of medical procedure that involves invasive surgical techniques. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -54,6 +54,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -106,47 +106,40 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type DiagnosticProcedureBase = MedicalProcedureBase;
     type DiagnosticProcedureLeaf = {
         \\"@type\\": \\"DiagnosticProcedure\\";
-    } & DiagnosticProcedureBase;
+    } & ThingBase;
     export type DiagnosticProcedure = DiagnosticProcedureLeaf;
 
-    type EnumerationBase = IntangibleBase;
     type EnumerationLeaf = {
         \\"@type\\": \\"Enumeration\\";
-    } & EnumerationBase;
+    } & ThingBase;
     export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
-    type IntangibleBase = ThingBase;
     type IntangibleLeaf = {
         \\"@type\\": \\"Intangible\\";
-    } & IntangibleBase;
+    } & ThingBase;
     export type Intangible = IntangibleLeaf | Enumeration;
 
-    type MedicalEntityBase = ThingBase;
     type MedicalEntityLeaf = {
         \\"@type\\": \\"MedicalEntity\\";
-    } & MedicalEntityBase;
+    } & ThingBase;
     export type MedicalEntity = MedicalEntityLeaf | MedicalProcedure;
 
-    type MedicalEnumerationBase = EnumerationBase;
     type MedicalEnumerationLeaf = {
         \\"@type\\": \\"MedicalEnumeration\\";
-    } & MedicalEnumerationBase;
+    } & ThingBase;
     export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType | PhysicalExam;
 
-    type MedicalProcedureBase = MedicalEntityBase;
     type MedicalProcedureLeaf = {
         \\"@type\\": \\"MedicalProcedure\\";
-    } & MedicalProcedureBase;
+    } & ThingBase;
     /** A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques. */
     export type MedicalProcedure = MedicalProcedureLeaf | DiagnosticProcedure | PalliativeProcedure | PhysicalExam | SurgicalProcedure | TherapeuticProcedure;
 
-    type MedicalProcedureTypeBase = MedicalEnumerationBase;
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
-    } & MedicalProcedureTypeBase;
+    } & ThingBase;
     /** An enumeration that describes different types of medical procedures. */
     export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
@@ -154,19 +147,18 @@ test(`baseine_${basename(__filename)}`, async () => {
         PercutaneousProcedure: (\\"http://schema.org/PercutaneousProcedure\\" as const)
     };
 
-    type MedicalTherapyBase = TherapeuticProcedureBase;
     type MedicalTherapyLeaf = {
         \\"@type\\": \\"MedicalTherapy\\";
-    } & MedicalTherapyBase;
+    } & ThingBase;
     export type MedicalTherapy = MedicalTherapyLeaf | PalliativeProcedure;
 
-    type PalliativeProcedureBase = (MedicalProcedureBase & MedicalTherapyBase);
+    type PalliativeProcedureBase = (ThingBase & ThingBase);
     type PalliativeProcedureLeaf = {
         \\"@type\\": \\"PalliativeProcedure\\";
     } & PalliativeProcedureBase;
     export type PalliativeProcedure = PalliativeProcedureLeaf;
 
-    type PhysicalExamBase = (MedicalProcedureBase & MedicalEnumerationBase);
+    type PhysicalExamBase = (ThingBase & ThingBase);
     type PhysicalExamLeaf = {
         \\"@type\\": \\"PhysicalExam\\";
     } & PhysicalExamBase;
@@ -176,17 +168,15 @@ test(`baseine_${basename(__filename)}`, async () => {
         Neuro: (\\"http://schema.org/Neuro\\" as const)
     };
 
-    type SurgicalProcedureBase = MedicalProcedureBase;
     type SurgicalProcedureLeaf = {
         \\"@type\\": \\"SurgicalProcedure\\";
-    } & SurgicalProcedureBase;
+    } & ThingBase;
     /** A medical procedure involving an incision with instruments; performed for diagnose, or therapeutic purposes. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 
-    type TherapeuticProcedureBase = MedicalProcedureBase;
     type TherapeuticProcedureLeaf = {
         \\"@type\\": \\"TherapeuticProcedure\\";
-    } & TherapeuticProcedureBase;
+    } & ThingBase;
     export type TherapeuticProcedure = TherapeuticProcedureLeaf | MedicalTherapy;
 
     type ThingBase = {

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -79,6 +79,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
@@ -190,7 +192,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type ThingBase = {
         /** IRI identifying the canonical address of this object. */
         \\"@id\\"?: string;
-        \\"procedureType\\"?: MedicalProcedureType | readonly MedicalProcedureType[];
+        \\"procedureType\\"?: SchemaValue<MedicalProcedureType>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/url_test.ts
+++ b/test/baselines/url_test.ts
@@ -65,9 +65,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type URLBase = Text;
     /** Data type: URL. */
-    export type URL = URLBase;
+    export type URL = Text;
 
     "
   `);

--- a/test/baselines/url_test.ts
+++ b/test/baselines/url_test.ts
@@ -38,6 +38,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@context\\": \\"https://schema.org\\";
     };
 
+    type SchemaValue<T> = T | readonly T[];
+
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -93,7 +93,21 @@ describe('Class', () => {
       addParent(cls, 'https://schema.org/Thing');
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonBase = ThingBase;
+        "type PersonLeaf = {
+            \\"@type\\": \\"Person\\";
+        } & ThingBase;
+        export type Person = PersonLeaf;"
+      `);
+    });
+
+    it('empty (two parents)', () => {
+      const ctx = new Context();
+      ctx.setUrlContext('https://schema.org/');
+      addParent(cls, 'https://schema.org/Thing1');
+      addParent(cls, 'https://schema.org/Thing2');
+
+      expect(asString(cls, ctx)).toMatchInlineSnapshot(`
+        "type PersonBase = (Thing1Base & Thing2Base);
         type PersonLeaf = {
             \\"@type\\": \\"Person\\";
         } & PersonBase;
@@ -117,10 +131,9 @@ describe('Class', () => {
       ).toBe(true);
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonBase = ThingBase;
-        type PersonLeaf = {
+        "type PersonLeaf = {
             \\"@type\\": \\"Person\\";
-        } & PersonBase;
+        } & ThingBase;
         /** @deprecated Use CoolPerson instead. */
         export type Person = PersonLeaf;"
       `);
@@ -158,10 +171,9 @@ describe('Class', () => {
       ).toBe(true);
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonBase = ThingBase;
-        type PersonLeaf = {
+        "type PersonLeaf = {
             \\"@type\\": \\"Person\\";
-        } & PersonBase;
+        } & ThingBase;
         /** @deprecated Use APerson or CoolPerson instead. */
         export type Person = PersonLeaf;"
       `);
@@ -192,10 +204,9 @@ describe('Class', () => {
       ).toBe(true);
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonBase = ThingBase;
-        type PersonLeaf = {
+        "type PersonLeaf = {
             \\"@type\\": \\"Person\\";
-        } & PersonBase;
+        } & ThingBase;
         /**
          * Fantastic
          * @deprecated Use CoolPerson instead.


### PR DESCRIPTION
Two changes:

1. Define and use:

   ```ts
   declare type SchemaValue<T> = T | readonly T[];
   ```

   for property values instead of always typing `(Foo | Bar | Baz) | readonly (Foo | Bar | Baz)[];`

2. Skip empty Base types. This shaves 500+ lines, and node declarations that are unnecessary.


SchemaValue paves the way to make it easier to refer to "Reference objects" (i.e. `{ "@id": "xyz" }`) within a Graph.