### PR TITLE
Cleaner Types, Properties, and DataTypes

### DIFF
--- a/src/transform/toClass.ts
+++ b/src/transform/toClass.ts
@@ -45,31 +45,15 @@ function toClass(cls: Class, topic: Topic, map: ClassMap): Class {
 }
 
 const wellKnownTypes = [
-  new Builtin('http://schema.org/Text', 'string', 'Data type: Text.'),
-  new Builtin('http://schema.org/Number', 'number', 'Data type: Number.'),
-  new Builtin(
-    'http://schema.org/Time',
-    'string',
-    'DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00.'
-  ),
-  new Builtin(
-    'http://schema.org/Date',
-    'string',
-    'A date value in <a href="http://en.wikipedia.org/wiki/ISO_8601">' +
-      'ISO 8601 date format</a>.'
-  ),
-  new Builtin(
-    'http://schema.org/DateTime',
-    'string',
-    'A combination of date and time of day in the form ' +
-      '[-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] ' +
-      '(see Chapter 5.4 of ISO 8601).'
-  ),
+  new Builtin('http://schema.org/Text', 'string'),
+  new Builtin('http://schema.org/Number', 'number'),
+  new Builtin('http://schema.org/Time', 'string'),
+  new Builtin('http://schema.org/Date', 'string'),
+  new Builtin('http://schema.org/DateTime', 'string'),
   new BooleanEnum(
     'http://schema.org/Boolean',
     'https://schema.org/True',
-    'https://schema.org/False',
-    'Boolean: True or False.'
+    'https://schema.org/False'
   ),
 ];
 
@@ -89,11 +73,7 @@ const wellKnownStrings = [
 
 function ForwardDeclareClasses(topics: readonly TypedTopic[]): ClassMap {
   const classes = new Map<string, Class>();
-  const dataType = new DataTypeUnion(
-    'http://schema.org/DataType',
-    [],
-    'The basic data types such as Integers, Strings, etc.'
-  );
+  const dataType = new DataTypeUnion('http://schema.org/DataType', []);
 
   for (const topic of topics) {
     if (IsDataType(topic.Subject)) {

--- a/src/transform/toClass.ts
+++ b/src/transform/toClass.ts
@@ -17,7 +17,7 @@
 import {Log} from '../logging';
 import {ObjectPredicate, Topic, TypedTopic} from '../triples/triple';
 import {UrlNode} from '../triples/types';
-import {IsClass, IsWellKnown, IsDataType} from '../triples/wellKnown';
+import {IsNamedClass, IsWellKnown, IsDataType} from '../triples/wellKnown';
 import {
   BooleanEnum,
   Builtin,
@@ -109,7 +109,7 @@ function ForwardDeclareClasses(topics: readonly TypedTopic[]): ClassMap {
       classes.set(topic.Subject.toString(), wk);
       dataType.wk.push(wk);
       continue;
-    } else if (!IsClass(topic)) continue;
+    } else if (!IsNamedClass(topic)) continue;
 
     const allowString = wellKnownStrings.some(wks =>
       wks.equivTo(topic.Subject)
@@ -125,7 +125,7 @@ function ForwardDeclareClasses(topics: readonly TypedTopic[]): ClassMap {
 
 function BuildClasses(topics: readonly TypedTopic[], classes: ClassMap) {
   for (const topic of topics) {
-    if (!IsClass(topic)) continue;
+    if (!IsNamedClass(topic)) continue;
 
     const cls = classes.get(topic.Subject.toString());
     assert(cls);

--- a/src/transform/toClass.ts
+++ b/src/transform/toClass.ts
@@ -20,7 +20,7 @@ import {UrlNode} from '../triples/types';
 import {IsNamedClass, IsWellKnown, IsDataType} from '../triples/wellKnown';
 import {
   BooleanEnum,
-  Builtin,
+  AliasBuiltin,
   Class,
   ClassMap,
   DataTypeUnion,
@@ -45,11 +45,11 @@ function toClass(cls: Class, topic: Topic, map: ClassMap): Class {
 }
 
 const wellKnownTypes = [
-  new Builtin('http://schema.org/Text', 'string'),
-  new Builtin('http://schema.org/Number', 'number'),
-  new Builtin('http://schema.org/Time', 'string'),
-  new Builtin('http://schema.org/Date', 'string'),
-  new Builtin('http://schema.org/DateTime', 'string'),
+  new AliasBuiltin('http://schema.org/Text', 'string'),
+  new AliasBuiltin('http://schema.org/Number', 'number'),
+  new AliasBuiltin('http://schema.org/Time', 'string'),
+  new AliasBuiltin('http://schema.org/Date', 'string'),
+  new AliasBuiltin('http://schema.org/DateTime', 'string'),
   new BooleanEnum(
     'http://schema.org/Boolean',
     'https://schema.org/True',

--- a/src/transform/toClass.ts
+++ b/src/transform/toClass.ts
@@ -18,13 +18,7 @@ import {Log} from '../logging';
 import {ObjectPredicate, Topic, TypedTopic} from '../triples/triple';
 import {UrlNode} from '../triples/types';
 import {IsNamedClass, IsWellKnown, IsDataType} from '../triples/wellKnown';
-import {
-  BooleanEnum,
-  AliasBuiltin,
-  Class,
-  ClassMap,
-  DataTypeUnion,
-} from '../ts/class';
+import {AliasBuiltin, Class, ClassMap, DataTypeUnion} from '../ts/class';
 import {assert} from '../util/assert';
 
 function toClass(cls: Class, topic: Topic, map: ClassMap): Class {
@@ -50,11 +44,7 @@ const wellKnownTypes = [
   new AliasBuiltin('http://schema.org/Time', 'string'),
   new AliasBuiltin('http://schema.org/Date', 'string'),
   new AliasBuiltin('http://schema.org/DateTime', 'string'),
-  new BooleanEnum(
-    'http://schema.org/Boolean',
-    'https://schema.org/True',
-    'https://schema.org/False'
-  ),
+  new AliasBuiltin('http://schema.org/Boolean', 'boolean'),
 ];
 
 // Should we allow 'string' to be a valid type for all values of this type?

--- a/src/triples/types.ts
+++ b/src/triples/types.ts
@@ -59,8 +59,9 @@ export class UrlNode {
     return this.href;
   }
 
-  matchesContext(contextString: string): boolean {
-    const context = fromString(contextString);
+  matchesContext(contextIn: string | ReadonlyUrl): boolean {
+    const context =
+      typeof contextIn === 'string' ? fromString(contextIn) : contextIn;
     if (this.context.protocol !== context.protocol) {
       // Schema.org schema uses 'http:' as protocol, but increasingly Schema.org
       // recommends using https: instead.
@@ -81,8 +82,11 @@ export class UrlNode {
     );
   }
 
-  equals(other: UrlNode): boolean {
-    return this.href === other.href;
+  equivTo(other: UrlNode): boolean {
+    return (
+      this.href === other.href ||
+      (this.matchesContext(other.context) && this.name === other.name)
+    );
   }
 
   static Parse(urlString: string): UrlNode {

--- a/src/triples/wellKnown.ts
+++ b/src/triples/wellKnown.ts
@@ -90,15 +90,10 @@ export function IsWellKnown(topic: TypedTopic): boolean {
   return false;
 }
 
-/** Returns true iff a Topic represents a non-DataType class. */
-export function IsClass(topic: TypedTopic): boolean {
-  // Skip all Native types. These are covered in wellKnownTypes.
-  if (IsWellKnown(topic)) return false;
-
+/** Returns true iff a Topic represents a named class. */
+export function IsNamedClass(topic: TypedTopic): boolean {
   // Skip anything that isn't a class.
-  if (!topic.types.some(IsClassType)) return false;
-
-  return true;
+  return topic.types.some(IsClassType);
 }
 
 /**

--- a/src/triples/wellKnown.ts
+++ b/src/triples/wellKnown.ts
@@ -83,13 +83,17 @@ export function IsDataType(t: TTypeName): boolean {
   return IsSchemaObject(t) && t.name === 'DataType';
 }
 
+/** Returns true iff a Topic represents a DataType. */
+export function IsWellKnown(topic: TypedTopic): boolean {
+  if (topic.types.some(IsDataType)) return true;
+  if (IsDataType(topic.Subject)) return true;
+  return false;
+}
+
 /** Returns true iff a Topic represents a non-DataType class. */
 export function IsClass(topic: TypedTopic): boolean {
   // Skip all Native types. These are covered in wellKnownTypes.
-  if (topic.types.some(IsDataType)) return false;
-
-  // Skip the DataType Type itself.
-  if (IsDataType(topic.Subject)) return false;
+  if (IsWellKnown(topic)) return false;
 
   // Skip anything that isn't a class.
   if (!topic.types.some(IsClassType)) return false;

--- a/src/triples/wellKnown.ts
+++ b/src/triples/wellKnown.ts
@@ -86,7 +86,6 @@ export function IsDataType(t: TTypeName): boolean {
 /** Returns true iff a Topic represents a DataType. */
 export function IsWellKnown(topic: TypedTopic): boolean {
   if (topic.types.some(IsDataType)) return true;
-  if (IsDataType(topic.Subject)) return true;
   return false;
 }
 

--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -406,10 +406,15 @@ export class Class {
 }
 
 /**
- * Represents a DataType. A "Native" Schema.org object that is best represented
+ * Represents a DataType.
+ */
+export class Builtin extends Class {}
+
+/**
+ * A "Native" Schema.org object that is best represented
  * in JSON-LD and JavaScript as a typedef to a native type.
  */
-export class Builtin extends Class {
+export class AliasBuiltin extends Builtin {
   constructor(url: string, private readonly equivTo: string) {
     super(UrlNode.Parse(url), false);
   }
@@ -435,7 +440,7 @@ export class Builtin extends Class {
 }
 export class BooleanEnum extends Builtin {
   constructor(url: string, private trueUrl: string, private falseUrl: string) {
-    super(url, '');
+    super(UrlNode.Parse(url), false);
   }
 
   toNode(): readonly Statement[] {
@@ -492,7 +497,7 @@ export class BooleanEnum extends Builtin {
 
 export class DataTypeUnion extends Builtin {
   constructor(url: string, readonly wk: Builtin[]) {
-    super(url, '');
+    super(UrlNode.Parse(url), false);
   }
 
   toNode(): DeclarationStatement[] {

--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -41,7 +41,12 @@ import {
 import {Log} from '../logging';
 import {TObject, TPredicate, TSubject} from '../triples/triple';
 import {UrlNode} from '../triples/types';
-import {GetComment, GetSubClassOf, IsSupersededBy} from '../triples/wellKnown';
+import {
+  GetComment,
+  GetSubClassOf,
+  IsSupersededBy,
+  IsClassType,
+} from '../triples/wellKnown';
 
 import {Context} from './context';
 import {EnumValue} from './enum';
@@ -162,6 +167,10 @@ export class Class {
     }
     const s = GetSubClassOf(value);
     if (s) {
+      // DataType subclasses rdfs:Class (since it too is a 'meta' type).
+      // We don't represent this well right now, but we want to skip it.
+      if (IsClassType(s.subClassOf)) return false;
+
       const parentClass = classMap.get(s.subClassOf.toString());
       if (parentClass) {
         this.parents.push(parentClass);

--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -485,7 +485,7 @@ export class BooleanEnum extends Builtin {
 }
 
 export class DataTypeUnion extends Builtin {
-  constructor(url: string, private readonly wk: Builtin[], doc: string) {
+  constructor(url: string, readonly wk: Builtin[], doc: string) {
     super(url, '', doc);
   }
 

--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -326,13 +326,7 @@ export class Class {
 
     if (isEnum) {
       return createUnionTypeNode([
-        ...this.enums().map(e => e.toTypeLiteral()),
-        ...this.enums()
-          .map(e => [context.getScopedName(e.value), e.value.href])
-          .filter(([scoped, href]) => scoped !== href)
-          .map(([scoped]) =>
-            createLiteralTypeNode(createStringLiteral(scoped))
-          ),
+        ...this.enums().flatMap(e => e.toTypeLiteral(context)),
         ...this.nonEnumType(skipDeprecated),
       ]);
     } else {

--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -97,7 +97,7 @@ export class Class {
     return this._supersededBy.size > 0;
   }
 
-  private get comment() {
+  protected get comment() {
     if (!this.deprecated) return this._comment;
     const deprecated = `@deprecated Use ${this.supersededBy()
       .map(c => c.className())
@@ -410,18 +410,14 @@ export class Class {
  * in JSON-LD and JavaScript as a typedef to a native type.
  */
 export class Builtin extends Class {
-  constructor(
-    url: string,
-    private readonly equivTo: string,
-    protected readonly doc: string
-  ) {
+  constructor(url: string, private readonly equivTo: string) {
     super(UrlNode.Parse(url), false);
   }
 
   toNode(): readonly Statement[] {
     return [
       withComments(
-        this.doc,
+        this.comment,
         createTypeAliasDeclaration(
           /*decorators=*/ [],
           createModifiersFromModifierFlags(ModifierFlags.Export),
@@ -438,19 +434,14 @@ export class Builtin extends Class {
   }
 }
 export class BooleanEnum extends Builtin {
-  constructor(
-    url: string,
-    private trueUrl: string,
-    private falseUrl: string,
-    doc: string
-  ) {
-    super(url, '', doc);
+  constructor(url: string, private trueUrl: string, private falseUrl: string) {
+    super(url, '');
   }
 
   toNode(): readonly Statement[] {
     return [
       withComments(
-        this.doc,
+        this.comment,
         createTypeAliasDeclaration(
           /*decotrators=*/ [],
           createModifiersFromModifierFlags(ModifierFlags.Export),
@@ -500,14 +491,14 @@ export class BooleanEnum extends Builtin {
 }
 
 export class DataTypeUnion extends Builtin {
-  constructor(url: string, readonly wk: Builtin[], doc: string) {
-    super(url, '', doc);
+  constructor(url: string, readonly wk: Builtin[]) {
+    super(url, '');
   }
 
   toNode(): DeclarationStatement[] {
     return [
       withComments(
-        this.doc,
+        this.comment,
         createTypeAliasDeclaration(
           /*decorators=*/ [],
           createModifiersFromModifierFlags(ModifierFlags.Export),

--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -15,11 +15,9 @@
  */
 import {
   createIntersectionTypeNode,
-  createLiteralTypeNode,
   createModifiersFromModifierFlags,
   createObjectLiteral,
   createParenthesizedType,
-  createStringLiteral,
   createTypeAliasDeclaration,
   createTypeLiteralNode,
   createTypeReferenceNode,

--- a/src/ts/enum.ts
+++ b/src/ts/enum.ts
@@ -19,6 +19,7 @@ import {
   createPropertyAssignment,
   createStringLiteral,
   createTypeReferenceNode,
+  TypeNode,
 } from 'typescript';
 
 import {Log} from '../logging';
@@ -28,6 +29,7 @@ import {GetComment, IsClassType, IsDataType} from '../triples/wellKnown';
 import {ClassMap} from './class';
 import {withComments} from './util/comments';
 import {toEnumName} from './util/names';
+import {Context} from './context';
 
 /**
  * Corresponds to a value that belongs to an Enumeration.
@@ -104,7 +106,23 @@ export class EnumValue {
     );
   }
 
-  toTypeLiteral() {
-    return createLiteralTypeNode(createStringLiteral(this.value.toString()));
+  toTypeLiteral(context: Context): TypeNode[] {
+    const types = [
+      createLiteralTypeNode(createStringLiteral(this.value.toString())),
+    ];
+    if (this.value.context.protocol === 'http:') {
+      types.push(
+        createLiteralTypeNode(
+          createStringLiteral(this.value.toString().replace(/^http:/, 'https:'))
+        )
+      );
+    }
+
+    const scoped = context.getScopedName(this.value);
+    if (scoped !== this.value.href) {
+      types.push(createLiteralTypeNode(createStringLiteral(scoped)));
+    }
+
+    return types;
   }
 }

--- a/src/ts/helper_types.ts
+++ b/src/ts/helper_types.ts
@@ -1,32 +1,58 @@
 import {
   createTypeAliasDeclaration,
-  createIdentifier,
   createTypeParameterDeclaration,
   createUnionTypeNode,
   createTypeReferenceNode,
   createTypeOperatorNode,
   createArrayTypeNode,
   SyntaxKind,
+  createTypeLiteralNode,
+  createPropertySignature,
+  createStringLiteral,
 } from 'typescript';
 
+import {withComments} from './util/comments';
+
+function IdPropertyNode() {
+  return withComments(
+    'IRI identifying the canonical address of this object.',
+    createPropertySignature(
+      /* modifiers= */ [],
+      createStringLiteral('@id'),
+      /* questionToken= */ undefined,
+      /* typeNode= */
+      createTypeReferenceNode('string', /*typeArguments=*/ []),
+      /* initializer= */ undefined
+    )
+  );
+}
+
 export const SchemaValueName = 'SchemaValue';
+export const IdReferenceName = 'IdReference';
 
 export function HelperTypes() {
   return [
     createTypeAliasDeclaration(
-      undefined,
-      undefined,
-      createIdentifier(SchemaValueName),
-      [createTypeParameterDeclaration(createIdentifier('T'))],
+      /*decorators=*/ [],
+      /*modifiers=*/ [],
+      SchemaValueName,
+      [createTypeParameterDeclaration('T')],
       createUnionTypeNode([
-        createTypeReferenceNode(createIdentifier('T'), undefined),
+        createTypeReferenceNode('T', /*typeArguments=*/ []),
         createTypeOperatorNode(
           SyntaxKind.ReadonlyKeyword,
           createArrayTypeNode(
-            createTypeReferenceNode(createIdentifier('T'), undefined)
+            createTypeReferenceNode('T', /*typeArguments=*/ [])
           )
         ),
       ])
+    ),
+    createTypeAliasDeclaration(
+      /*decorators=*/ [],
+      /*modifiers=*/ [],
+      IdReferenceName,
+      /*typeParameters=*/ [],
+      createTypeLiteralNode([IdPropertyNode()])
     ),
   ];
 }

--- a/test/baselines/category_test.ts
+++ b/test/baselines/category_test.ts
@@ -52,30 +52,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type DistilleryLeaf = {
         \\"@type\\": \\"Distillery\\";

--- a/test/baselines/category_test.ts
+++ b/test/baselines/category_test.ts
@@ -45,6 +45,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -77,9 +81,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** A distillery. */
     export type Distillery = DistilleryLeaf;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {

--- a/test/baselines/category_test.ts
+++ b/test/baselines/category_test.ts
@@ -34,6 +34,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/Distillery> <http://schema.org/category> "issue-743" .
 <http://schema.org/Distillery> <http://www.w3.org/2000/01/rdf-schema#label> "Distillery" .
 <http://schema.org/Distillery> <http://www.w3.org/2000/01/rdf-schema#comment> "A distillery." .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`, '--verbose']
   );

--- a/test/baselines/category_test.ts
+++ b/test/baselines/category_test.ts
@@ -52,7 +52,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Text. */
     export type Text = string;
 
     type DistilleryLeaf = {

--- a/test/baselines/comments_test.ts
+++ b/test/baselines/comments_test.ts
@@ -52,30 +52,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type ThingBase = Partial<IdReference> & {
         /**

--- a/test/baselines/comments_test.ts
+++ b/test/baselines/comments_test.ts
@@ -45,6 +45,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -71,9 +75,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         /**
          * Reminds me of this quote:
          * \`FooBar\`

--- a/test/baselines/comments_test.ts
+++ b/test/baselines/comments_test.ts
@@ -34,6 +34,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/knows> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
 <http://schema.org/knows> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
 <http://schema.org/knows> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/comments_test.ts
+++ b/test/baselines/comments_test.ts
@@ -36,6 +36,7 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/knows> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
 <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text> <http://www.w3.org/2000/01/rdf-schema#comment> "Data type: Text." .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/data_type_union_test.ts
+++ b/test/baselines/data_type_union_test.ts
@@ -35,6 +35,7 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
 <http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/DataType> <http://www.w3.org/2000/01/rdf-schema#comment> "The basic data types such as Integers, Strings, etc." .
 <http://schema.org/DataType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/DataType> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,

--- a/test/baselines/data_type_union_test.ts
+++ b/test/baselines/data_type_union_test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Baseline tests are a set of tests (in tests/baseline/) that
+ * correspond to full comparisons of a generate .ts output based on a set of
+ * Triples representing an entire ontology.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver';
+
+test(`baseine_${basename(__filename)}`, async () => {
+  const {actual} = await inlineCli(
+    `
+<http://schema.org/name> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+<http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/age> <http://schema.org/rangeIncludes> <http://schema.org/Number> .
+<http://schema.org/age> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/age> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/DataType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+      `,
+    ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
+  );
+
+  expect(actual).toMatchInlineSnapshot(`
+    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+    export type WithContext<T extends Thing> = T & {
+        \\"@context\\": \\"https://schema.org\\";
+    };
+
+    type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
+
+    /** Data type: Number. */
+    export type Number = number;
+
+    /** Data type: Text. */
+    export type Text = string;
+
+    /** The basic data types such as Integers, Strings, etc. */
+    export type DataType = Text | Number;
+
+    type ThingBase = Partial<IdReference> & {
+        \\"age\\"?: SchemaValue<Number>;
+        \\"name\\"?: SchemaValue<Text>;
+    };
+    type ThingLeaf = {
+        \\"@type\\": \\"Thing\\";
+    } & ThingBase;
+    export type Thing = ThingLeaf;
+
+    "
+  `);
+});

--- a/test/baselines/data_type_union_test.ts
+++ b/test/baselines/data_type_union_test.ts
@@ -54,10 +54,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Number. */
     export type Number = number;
 
-    /** Data type: Text. */
     export type Text = string;
 
     /** The basic data types such as Integers, Strings, etc. */

--- a/test/baselines/data_type_union_test.ts
+++ b/test/baselines/data_type_union_test.ts
@@ -36,6 +36,7 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
 <http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/DataType> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/DataType> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/default_ontology_test.ts
+++ b/test/baselines/default_ontology_test.ts
@@ -36,6 +36,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -62,10 +66,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
-    };
+    type ThingBase = Partial<IdReference>;
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/default_ontology_test.ts
+++ b/test/baselines/default_ontology_test.ts
@@ -41,31 +41,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
-    /** Data type: Text. */
-    export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
     type ThingBase = Partial<IdReference>;
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/deprecated_objects_test.ts
+++ b/test/baselines/deprecated_objects_test.ts
@@ -72,10 +72,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Number. */
     export type Number = number;
 
-    /** Data type: Text. */
     export type Text = string;
 
     type CarBase = ThingBase & {

--- a/test/baselines/deprecated_objects_test.ts
+++ b/test/baselines/deprecated_objects_test.ts
@@ -63,6 +63,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -105,9 +109,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & PersonLikeBase;
     export type PersonLike = PersonLikeLeaf;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;
         /**
          * Names are great! {@link X Y}

--- a/test/baselines/deprecated_objects_test.ts
+++ b/test/baselines/deprecated_objects_test.ts
@@ -72,30 +72,11 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
     /** Data type: Number. */
     export type Number = number;
 
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type CarBase = ThingBase & {
         \\"doorNumber\\"?: SchemaValue<Number>;

--- a/test/baselines/deprecated_objects_test.ts
+++ b/test/baselines/deprecated_objects_test.ts
@@ -52,6 +52,10 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/names> <http://www.w3.org/2000/01/rdf-schema#comment> "Names are great!\\n <a href=\\"X\\">Y</a>" .
 <http://schema.org/names> <http://schema.org/supersededBy> <http://schema.org/name> .
 <http://schema.org/names> <http://schema.org/supersededBy> <http://schema.org/height> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -70,7 +70,7 @@ test(`baseine_${basename(__filename)}`, async () => {
      * - Bar
      * - _Baz_, and __Bat__
      */
-    export type Thing = \\"http://schema.org/Gadget\\" | \\"http://schema.org/Widget\\" | \\"Gadget\\" | \\"Widget\\" | ThingLeaf;
+    export type Thing = \\"http://schema.org/Gadget\\" | \\"https://schema.org/Gadget\\" | \\"Gadget\\" | \\"http://schema.org/Widget\\" | \\"https://schema.org/Widget\\" | \\"Widget\\" | ThingLeaf;
     export const Thing = {
         /** Complex! */
         Gadget: (\\"http://schema.org/Gadget\\" as const),

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -47,6 +47,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -73,9 +77,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         /** Names are great! {@link X Y} */
         \\"name\\"?: SchemaValue<Text>;
     };

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -54,30 +54,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type ThingBase = Partial<IdReference> & {
         /** Names are great! {@link X Y} */

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -71,7 +71,7 @@ test(`baseine_${basename(__filename)}`, async () => {
      * - Bar
      * - _Baz_, and __Bat__
      */
-    export type Thing = \\"http://schema.org/Gadget\\" | \\"http://schema.org/Widget\\" | ThingLeaf;
+    export type Thing = \\"http://schema.org/Gadget\\" | \\"http://schema.org/Widget\\" | \\"Gadget\\" | \\"Widget\\" | ThingLeaf;
     export const Thing = {
         /** Complex! */
         Gadget: (\\"http://schema.org/Gadget\\" as const),

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -36,6 +36,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/Gadget> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Thing> .
 <http://schema.org/Gadget> <http://www.w3.org/2000/01/rdf-schema#comment> "Simple!" .
 <http://schema.org/Gadget> <http://www.w3.org/2000/01/rdf-schema#comment> "Complex!" .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`, `--verbose`]
   );

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -54,7 +54,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Text. */
     export type Text = string;
 
     type ThingBase = Partial<IdReference> & {

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -48,31 +48,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
-    /** Data type: Text. */
-    export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
     type ThingBase = Partial<IdReference>;
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -53,7 +53,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     /** A Thing! */
-    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | \\"a\\" | \\"b\\" | \\"c\\" | \\"d\\" | ThingLeaf;
+    export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | ThingLeaf;
     export const Thing = {
         a: (\\"http://schema.org/a\\" as const),
         b: (\\"http://schema.org/b\\" as const),

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -53,7 +53,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     /** A Thing! */
-    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | ThingLeaf;
+    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | \\"a\\" | \\"b\\" | \\"c\\" | \\"d\\" | ThingLeaf;
     export const Thing = {
         a: (\\"http://schema.org/a\\" as const),
         b: (\\"http://schema.org/b\\" as const),

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -28,6 +28,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Thing> .
 <http://schema.org/c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Thing> .
 <http://schema.org/d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Thing> .
+<https://schema.org/e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Thing> .
+<http://google.com/f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Thing> .
 <http://schema.org/c> <http://www.w3.org/2000/01/rdf-schema#comment> "A letter!" .
 <http://schema.org/c> <http://schema.org/category> "issue-1156" .
 <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
@@ -53,13 +55,15 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     /** A Thing! */
-    export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | ThingLeaf;
+    export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | \\"https://schema.org/e\\" | \\"e\\" | \\"http://google.com/f\\" | \\"https://google.com/f\\" | ThingLeaf;
     export const Thing = {
         a: (\\"http://schema.org/a\\" as const),
         b: (\\"http://schema.org/b\\" as const),
         /** A letter! */
         c: (\\"http://schema.org/c\\" as const),
-        d: (\\"http://schema.org/d\\" as const)
+        d: (\\"http://schema.org/d\\" as const),
+        e: (\\"https://schema.org/e\\" as const),
+        f: (\\"http://google.com/f\\" as const)
     };
 
     "

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -43,6 +43,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -69,10 +73,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
-    };
+    type ThingBase = Partial<IdReference>;
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/inheritance_multiple_test.ts
+++ b/test/baselines/inheritance_multiple_test.ts
@@ -58,30 +58,11 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
     /** Data type: Number. */
     export type Number = number;
 
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type PersonLikeBase = ThingBase & {
         \\"height\\"?: SchemaValue<Number>;

--- a/test/baselines/inheritance_multiple_test.ts
+++ b/test/baselines/inheritance_multiple_test.ts
@@ -58,10 +58,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Number. */
     export type Number = number;
 
-    /** Data type: Text. */
     export type Text = string;
 
     type PersonLikeBase = ThingBase & {

--- a/test/baselines/inheritance_multiple_test.ts
+++ b/test/baselines/inheritance_multiple_test.ts
@@ -38,6 +38,10 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/PersonLike> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Thing> .
 <http://schema.org/Vehicle> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/Vehicle> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Thing> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/inheritance_multiple_test.ts
+++ b/test/baselines/inheritance_multiple_test.ts
@@ -49,6 +49,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -83,9 +87,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & PersonLikeBase;
     export type PersonLike = PersonLikeLeaf;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {

--- a/test/baselines/inheritance_one_test.ts
+++ b/test/baselines/inheritance_one_test.ts
@@ -44,6 +44,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -78,9 +82,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & PersonLikeBase;
     export type PersonLike = PersonLikeLeaf;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {

--- a/test/baselines/inheritance_one_test.ts
+++ b/test/baselines/inheritance_one_test.ts
@@ -33,6 +33,10 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/height> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <http://schema.org/PersonLike> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/PersonLike> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Thing> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/inheritance_one_test.ts
+++ b/test/baselines/inheritance_one_test.ts
@@ -53,10 +53,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Number. */
     export type Number = number;
 
-    /** Data type: Text. */
     export type Text = string;
 
     type PersonLikeBase = ThingBase & {

--- a/test/baselines/inheritance_one_test.ts
+++ b/test/baselines/inheritance_one_test.ts
@@ -53,30 +53,11 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
     /** Data type: Number. */
     export type Number = number;
 
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type PersonLikeBase = ThingBase & {
         \\"height\\"?: SchemaValue<Number>;

--- a/test/baselines/must_define_datatype_test.ts
+++ b/test/baselines/must_define_datatype_test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Baseline tests are a set of tests (in tests/baseline/) that
+ * correspond to full comparisons of a generate .ts output based on a set of
+ * Triples representing an entire ontology.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver';
+
+test(`baseline_${basename(__filename)}`, async () => {
+  await expect(
+    inlineCli(
+      `
+<http://schema.org/name> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+<http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+      `,
+      ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
+    )
+  ).rejects.toThrow('Could not find class for http://schema.org/Text');
+});

--- a/test/baselines/nodeprecated_objects_test.ts
+++ b/test/baselines/nodeprecated_objects_test.ts
@@ -76,30 +76,11 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
     /** Data type: Number. */
     export type Number = number;
 
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type CarBase = ThingBase & {
         \\"doorNumber\\"?: SchemaValue<Number>;

--- a/test/baselines/nodeprecated_objects_test.ts
+++ b/test/baselines/nodeprecated_objects_test.ts
@@ -52,6 +52,10 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/names> <http://www.w3.org/2000/01/rdf-schema#comment> "Names are great!\\n <a href=\\"X\\">Y</a>" .
 <http://schema.org/names> <http://schema.org/supersededBy> <http://schema.org/name> .
 <http://schema.org/names> <http://schema.org/supersededBy> <http://schema.org/height> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 `,
     [
       '--ontology',

--- a/test/baselines/nodeprecated_objects_test.ts
+++ b/test/baselines/nodeprecated_objects_test.ts
@@ -67,6 +67,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -109,9 +113,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & PersonLikeBase;
     export type PersonLike = PersonLikeLeaf;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {

--- a/test/baselines/nodeprecated_objects_test.ts
+++ b/test/baselines/nodeprecated_objects_test.ts
@@ -76,10 +76,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Number. */
     export type Number = number;
 
-    /** Data type: Text. */
     export type Text = string;
 
     type CarBase = ThingBase & {

--- a/test/baselines/property_edge_cases_test.ts
+++ b/test/baselines/property_edge_cases_test.ts
@@ -31,6 +31,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/knows> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
 <http://schema.org/knows> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`, `--verbose`]
   );

--- a/test/baselines/property_edge_cases_test.ts
+++ b/test/baselines/property_edge_cases_test.ts
@@ -49,7 +49,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Text. */
     export type Text = string;
 
     type ThingBase = Partial<IdReference> & {

--- a/test/baselines/property_edge_cases_test.ts
+++ b/test/baselines/property_edge_cases_test.ts
@@ -49,30 +49,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type ThingBase = Partial<IdReference> & {
         \\"knows\\"?: SchemaValue<never>;

--- a/test/baselines/property_edge_cases_test.ts
+++ b/test/baselines/property_edge_cases_test.ts
@@ -42,6 +42,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -68,9 +72,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"knows\\"?: SchemaValue<never>;
         \\"name\\"?: SchemaValue<Text>;
     };

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -42,6 +42,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/Duration> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/Mass> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/Energy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -60,7 +60,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Text. */
     export type Text = string;
 
     type DistanceLeaf = {

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -53,6 +53,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -109,9 +113,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type Quantity = QuantityLeaf | Distance | Duration | Energy | Mass | string;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -60,30 +60,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type DistanceLeaf = {
         \\"@type\\": \\"Distance\\";

--- a/test/baselines/simple_test.ts
+++ b/test/baselines/simple_test.ts
@@ -28,6 +28,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
 <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/simple_test.ts
+++ b/test/baselines/simple_test.ts
@@ -46,7 +46,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Text. */
     export type Text = string;
 
     type ThingBase = Partial<IdReference> & {

--- a/test/baselines/simple_test.ts
+++ b/test/baselines/simple_test.ts
@@ -39,6 +39,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -65,9 +69,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {

--- a/test/baselines/simple_test.ts
+++ b/test/baselines/simple_test.ts
@@ -46,30 +46,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -42,6 +42,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -68,10 +72,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
-    };
+    type ThingBase = Partial<IdReference>;
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -47,31 +47,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
-    /** Data type: Text. */
-    export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
     type ThingBase = Partial<IdReference>;
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -52,7 +52,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     /** A Thing! */
-    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | ThingLeaf;
+    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | \\"a\\" | \\"b\\" | \\"c\\" | \\"d\\" | ThingLeaf;
     export const Thing = {
         a: (\\"http://schema.org/a\\" as const),
         b: (\\"http://schema.org/b\\" as const),

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -52,7 +52,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     /** A Thing! */
-    export type Thing = \\"http://schema.org/a\\" | \\"http://schema.org/b\\" | \\"http://schema.org/c\\" | \\"http://schema.org/d\\" | \\"a\\" | \\"b\\" | \\"c\\" | \\"d\\" | ThingLeaf;
+    export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | ThingLeaf;
     export const Thing = {
         a: (\\"http://schema.org/a\\" as const),
         b: (\\"http://schema.org/b\\" as const),

--- a/test/baselines/sorted_props_test.ts
+++ b/test/baselines/sorted_props_test.ts
@@ -37,6 +37,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/d> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
 <http://schema.org/d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/sorted_props_test.ts
+++ b/test/baselines/sorted_props_test.ts
@@ -55,30 +55,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type ThingBase = Partial<IdReference> & {
         \\"a\\"?: SchemaValue<Text>;

--- a/test/baselines/sorted_props_test.ts
+++ b/test/baselines/sorted_props_test.ts
@@ -55,7 +55,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Text. */
     export type Text = string;
 
     type ThingBase = Partial<IdReference> & {

--- a/test/baselines/sorted_props_test.ts
+++ b/test/baselines/sorted_props_test.ts
@@ -48,6 +48,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -74,9 +78,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"a\\"?: SchemaValue<Text>;
         \\"b\\"?: SchemaValue<Text>;
         \\"c\\"?: SchemaValue<Text>;

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -44,6 +44,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -70,9 +74,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"a\\"?: SchemaValue<Boolean | Date | DateTime | Number | Text | Time>;
     };
     type ThingLeaf = {

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -63,10 +63,10 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
+    export type Boolean = \\"http://schema.org/False\\" | \\"https://schema.org/False\\" | \\"False\\" | \\"http://schema.org/True\\" | \\"https://schema.org/True\\" | \\"True\\" | boolean;
     export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
+        False: (\\"http://schema.org/False\\" as const),
+        True: (\\"http://schema.org/True\\" as const)
     };
 
     export type Date = string;

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -61,26 +61,20 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
     export const Boolean = {
         True: (\\"https://schema.org/True\\" as const),
         False: (\\"https://schema.org/False\\" as const)
     };
 
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
     export type Date = string;
 
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
     export type DateTime = string;
 
-    /** Data type: Number. */
     export type Number = number;
 
-    /** Data type: Text. */
     export type Text = string;
 
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
     export type Time = string;
 
     type ThingBase = Partial<IdReference> & {

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -33,6 +33,18 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/a> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
 <http://schema.org/a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Number> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/DateTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/DateTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Date> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Date> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Boolean> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Boolean> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Time> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Time> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -45,6 +45,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/Boolean> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/Time> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
 <http://schema.org/Time> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/True> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Boolean> .
+<http://schema.org/False> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Boolean> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -83,9 +83,6 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
     export type Time = string;
 
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
     type ThingBase = Partial<IdReference> & {
         \\"a\\"?: SchemaValue<Boolean | Date | DateTime | Number | Text | Time>;
     };

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -71,30 +71,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type EntryPointLeaf = {
         \\"@type\\": \\"EntryPoint\\";

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -50,6 +50,10 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/EntryPoint> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Thing> .
 <http://schema.org/urlTemplate> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <http://schema.org/urlTemplate> <http://schema.org/rangeIncludes> <http://schema.org/URL> .
+<http://schema.org/URL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Text> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/urlTemplate> <http://schema.org/domainIncludes> <http://schema.org/Organization> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -71,7 +71,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Text. */
     export type Text = string;
 
     type EntryPointLeaf = {

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -66,6 +66,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -98,8 +102,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type EntryPoint = EntryPointLeaf | string;
 
     type OrganizationBase = ThingBase & {
-        \\"locatedIn\\"?: SchemaValue<Place>;
-        \\"owner\\"?: SchemaValue<Person>;
+        \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
+        \\"owner\\"?: SchemaValue<Person | IdReference>;
         \\"urlTemplate\\"?: SchemaValue<URL>;
     };
     type OrganizationLeaf = {
@@ -108,8 +112,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type Organization = OrganizationLeaf | string;
 
     type PersonBase = ThingBase & {
-        \\"height\\"?: SchemaValue<Quantity>;
-        \\"locatedIn\\"?: SchemaValue<Place>;
+        \\"height\\"?: SchemaValue<Quantity | IdReference>;
+        \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
     };
     type PersonLeaf = {
         \\"@type\\": \\"Person\\";
@@ -126,15 +130,15 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type Quantity = QuantityLeaf | string;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
+
+    export type URL = Text;
 
     "
   `);

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -50,6 +50,10 @@ test(`baseine_${basename(__filename)}`, async () => {
 <https://schema.org/EntryPoint> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://schema.org/Thing> .
 <https://schema.org/urlTemplate> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <https://schema.org/urlTemplate> <https://schema.org/rangeIncludes> <https://schema.org/URL> .
+<https://schema.org/URL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Text> .
+<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <https://schema.org/urlTemplate> <https://schema.org/domainIncludes> <https://schema.org/Organization> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -66,31 +66,13 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
-
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
     };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
 
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     type EntryPointLeaf = {
         \\"@type\\": \\"EntryPoint\\";
@@ -98,8 +80,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type EntryPoint = EntryPointLeaf | string;
 
     type OrganizationBase = ThingBase & {
-        \\"locatedIn\\"?: SchemaValue<Place>;
-        \\"owner\\"?: SchemaValue<Person>;
+        \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
+        \\"owner\\"?: SchemaValue<Person | IdReference>;
         \\"urlTemplate\\"?: SchemaValue<URL>;
     };
     type OrganizationLeaf = {
@@ -108,8 +90,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     export type Organization = OrganizationLeaf | string;
 
     type PersonBase = ThingBase & {
-        \\"height\\"?: SchemaValue<Quantity>;
-        \\"locatedIn\\"?: SchemaValue<Place>;
+        \\"height\\"?: SchemaValue<Quantity | IdReference>;
+        \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
     };
     type PersonLeaf = {
         \\"@type\\": \\"Person\\";
@@ -126,15 +108,15 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type Quantity = QuantityLeaf | string;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
+    type ThingBase = Partial<IdReference> & {
         \\"name\\"?: SchemaValue<Text>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
+
+    export type URL = Text;
 
     "
   `);

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -50,10 +50,10 @@ test(`baseine_${basename(__filename)}`, async () => {
 <https://schema.org/EntryPoint> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://schema.org/Thing> .
 <https://schema.org/urlTemplate> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
 <https://schema.org/urlTemplate> <https://schema.org/rangeIncludes> <https://schema.org/URL> .
-<https://schema.org/URL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
-<https://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Text> .
-<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
-<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/URL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://schema.org/Text> .
+<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/DataType> .
+<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2000/01/rdf-schema#Class> .
 <https://schema.org/urlTemplate> <https://schema.org/domainIncludes> <https://schema.org/Organization> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -71,7 +71,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Text. */
     export type Text = string;
 
     type EntryPointLeaf = {

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -60,31 +60,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
-    /** Data type: Text. */
-    export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
     type EnumerationLeaf = {
         \\"@type\\": \\"Enumeration\\";
     } & ThingBase;

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -83,7 +83,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & ThingBase;
-    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
+    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"https://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -55,6 +55,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -116,10 +120,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** A type of medical procedure that involves invasive surgical techniques. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
-    };
+    type ThingBase = Partial<IdReference>;
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -83,7 +83,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & ThingBase;
-    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
+    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -60,31 +60,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
-    /** Data type: Text. */
-    export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
     type EnumerationLeaf = {
         \\"@type\\": \\"Enumeration\\";
     } & ThingBase;

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -83,7 +83,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & ThingBase;
-    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
+    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"https://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -55,6 +55,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -116,10 +120,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** A type of medical procedure that involves invasive surgical techniques. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
-    };
+    type ThingBase = Partial<IdReference>;
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -83,7 +83,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type MedicalProcedureTypeLeaf = {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & ThingBase;
-    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
+    export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         /** A type of medical procedure that involves invasive surgical techniques. */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -85,31 +85,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
-    /** Data type: Text. */
-    export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
-
     type DiagnosticProcedureLeaf = {
         \\"@type\\": \\"DiagnosticProcedure\\";
     } & ThingBase;

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -120,7 +120,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & ThingBase;
     /** An enumeration that describes different types of medical procedures. */
-    export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | MedicalProcedureTypeLeaf;
+    export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | \\"NoninvasiveProcedure\\" | \\"PercutaneousProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         NoninvasiveProcedure: (\\"http://schema.org/NoninvasiveProcedure\\" as const),
         PercutaneousProcedure: (\\"http://schema.org/PercutaneousProcedure\\" as const)
@@ -141,7 +141,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type PhysicalExamLeaf = {
         \\"@type\\": \\"PhysicalExam\\";
     } & PhysicalExamBase;
-    export type PhysicalExam = \\"http://schema.org/Head\\" | \\"http://schema.org/Neuro\\" | PhysicalExamLeaf;
+    export type PhysicalExam = \\"http://schema.org/Head\\" | \\"http://schema.org/Neuro\\" | \\"Head\\" | \\"Neuro\\" | PhysicalExamLeaf;
     export const PhysicalExam = {
         Head: (\\"http://schema.org/Head\\" as const),
         Neuro: (\\"http://schema.org/Neuro\\" as const)

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -120,7 +120,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & ThingBase;
     /** An enumeration that describes different types of medical procedures. */
-    export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | \\"NoninvasiveProcedure\\" | \\"PercutaneousProcedure\\" | MedicalProcedureTypeLeaf;
+    export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"https://schema.org/NoninvasiveProcedure\\" | \\"NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | \\"https://schema.org/PercutaneousProcedure\\" | \\"PercutaneousProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
         NoninvasiveProcedure: (\\"http://schema.org/NoninvasiveProcedure\\" as const),
         PercutaneousProcedure: (\\"http://schema.org/PercutaneousProcedure\\" as const)
@@ -141,7 +141,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     type PhysicalExamLeaf = {
         \\"@type\\": \\"PhysicalExam\\";
     } & PhysicalExamBase;
-    export type PhysicalExam = \\"http://schema.org/Head\\" | \\"http://schema.org/Neuro\\" | \\"Head\\" | \\"Neuro\\" | PhysicalExamLeaf;
+    export type PhysicalExam = \\"http://schema.org/Head\\" | \\"https://schema.org/Head\\" | \\"Head\\" | \\"http://schema.org/Neuro\\" | \\"https://schema.org/Neuro\\" | \\"Neuro\\" | PhysicalExamLeaf;
     export const PhysicalExam = {
         Head: (\\"http://schema.org/Head\\" as const),
         Neuro: (\\"http://schema.org/Neuro\\" as const)

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -80,6 +80,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
@@ -179,10 +183,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type TherapeuticProcedure = TherapeuticProcedureLeaf | MedicalTherapy;
 
-    type ThingBase = {
-        /** IRI identifying the canonical address of this object. */
-        \\"@id\\"?: string;
-        \\"procedureType\\"?: SchemaValue<MedicalProcedureType>;
+    type ThingBase = Partial<IdReference> & {
+        \\"procedureType\\"?: SchemaValue<MedicalProcedureType | IdReference>;
     };
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";

--- a/test/baselines/unknown_wellknown_test.ts
+++ b/test/baselines/unknown_wellknown_test.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Baseline tests are a set of tests (in tests/baseline/) that
+ * correspond to full comparisons of a generate .ts output based on a set of
+ * Triples representing an entire ontology.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver';
+
+test(`baseline_${basename(__filename)}`, async () => {
+  await expect(
+    inlineCli(
+      `
+<http://schema.org/name> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+<http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+      `,
+      ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
+    )
+  ).rejects.toThrow('has no corresponding well-known type');
+});

--- a/test/baselines/url_test.ts
+++ b/test/baselines/url_test.ts
@@ -28,6 +28,8 @@ test(`baseine_${basename(__filename)}`, async () => {
 <http://schema.org/URL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
 <http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#label> "URL" .
 <http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Text> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
       `,
     ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
   );

--- a/test/baselines/url_test.ts
+++ b/test/baselines/url_test.ts
@@ -46,7 +46,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Data type: Text. */
     export type Text = string;
 
     /** Data type: URL. */

--- a/test/baselines/url_test.ts
+++ b/test/baselines/url_test.ts
@@ -46,30 +46,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    /** Boolean: True or False. */
-    export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";
-    export const Boolean = {
-        True: (\\"https://schema.org/True\\" as const),
-        False: (\\"https://schema.org/False\\" as const)
-    };
-
-    /** A date value in {@link http://en.wikipedia.org/wiki/ISO_8601 ISO 8601 date format}. */
-    export type Date = string;
-
-    /** A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601). */
-    export type DateTime = string;
-
-    /** Data type: Number. */
-    export type Number = number;
-
     /** Data type: Text. */
     export type Text = string;
-
-    /** DateTime represented in string, e.g. 2017-01-04T17:10:00-05:00. */
-    export type Time = string;
-
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Text | Number | Time | Date | DateTime | Boolean;
 
     /** Data type: URL. */
     export type URL = Text;

--- a/test/baselines/url_test.ts
+++ b/test/baselines/url_test.ts
@@ -39,6 +39,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
 
     /** Boolean: True or False. */
     export type Boolean = true | false | \\"https://schema.org/True\\" | \\"https://schema.org/False\\";

--- a/test/triples/wellKnown_test.ts
+++ b/test/triples/wellKnown_test.ts
@@ -19,7 +19,7 @@ import {
   GetSubClassOf,
   GetType,
   GetTypes,
-  IsClass,
+  IsNamedClass,
 } from '../../src/triples/wellKnown';
 
 describe('wellKnown', () => {
@@ -259,32 +259,32 @@ describe('wellKnown', () => {
     });
   });
 
-  describe('IsClass', () => {
+  describe('IsNamedClass', () => {
     const cls = UrlNode.Parse('http://www.w3.org/2000/01/rdf-schema#Class');
     const dataType = UrlNode.Parse('http://schema.org/DataType');
     const bool = UrlNode.Parse('http://schema.org/Boolean');
 
-    it('a data type is not a class', () => {
+    it('a data type is a named class', () => {
       expect(
-        IsClass({
+        IsNamedClass({
           Subject: UrlNode.Parse('https://schema.org/Text'),
           types: [cls, dataType],
           values: [],
         })
-      ).toBe(false);
+      ).toBe(true);
 
       expect(
-        IsClass({
+        IsNamedClass({
           Subject: UrlNode.Parse('https://schema.org/Text'),
           types: [dataType, cls],
           values: [],
         })
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('an only-enum is not a class', () => {
       expect(
-        IsClass({
+        IsNamedClass({
           Subject: UrlNode.Parse('https://schema.org/True'),
           types: [bool],
           values: [],
@@ -294,7 +294,7 @@ describe('wellKnown', () => {
 
     it('an enum can still be a class', () => {
       expect(
-        IsClass({
+        IsNamedClass({
           Subject: UrlNode.Parse('https://schema.org/ItsComplicated'),
           types: [bool, cls],
           values: [],
@@ -302,9 +302,9 @@ describe('wellKnown', () => {
       ).toBe(true);
     });
 
-    it('the DataType union is not a class', () => {
+    it('the DataType union is a class', () => {
       expect(
-        IsClass({
+        IsNamedClass({
           Subject: UrlNode.Parse('https://schema.org/DataType'),
           types: [cls],
           values: [
@@ -318,7 +318,7 @@ describe('wellKnown', () => {
             },
           ],
         })
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 });

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -25,11 +25,11 @@ import {
 
 import {SchemaString, UrlNode} from '../../src/triples/types';
 import {
-  BooleanEnum,
   AliasBuiltin,
   Class,
   DataTypeUnion,
   Sort,
+  Builtin,
 } from '../../src/ts/class';
 import {Context} from '../../src/ts/context';
 import {makeClass, makeClassMap} from '../helpers/make_class';
@@ -343,14 +343,10 @@ describe('Sort(Class, Class)', () => {
         )
       ).toBe(-1);
 
-      // Can be same as more specific builtins.
+      // Can be same as less specific builtins.
       expect(
         Sort(
-          new BooleanEnum(
-            'https://schema.org/Boo',
-            'https://schema.org/B',
-            'https://schema.org/C'
-          ),
+          new Builtin(UrlNode.Parse('https://schema.org/Boo'), false),
           new AliasBuiltin('https://schema.org/Boo', 'Text')
         )
       ).toBe(0);
@@ -362,31 +358,11 @@ describe('Sort(Class, Class)', () => {
           new AliasBuiltin('https://schema.org/B', 'string')
         )
       ).toBe(-1);
-      expect(
-        Sort(
-          new AliasBuiltin('https://schema.org/A', 'string'),
-          new BooleanEnum(
-            'https://schema.org/B',
-            'https://schema.org/B',
-            'https://schema.org/C'
-          )
-        )
-      ).toBe(-1);
 
       expect(
         Sort(
           new AliasBuiltin('https://schema.org/B', 'string'),
           new AliasBuiltin('https://schema.org/A', 'string')
-        )
-      ).toBe(+1);
-      expect(
-        Sort(
-          new AliasBuiltin('https://schema.org/B', 'string'),
-          new BooleanEnum(
-            'https://schema.org/A',
-            'https://schema.org/B',
-            'https://schema.org/C'
-          )
         )
       ).toBe(+1);
 
@@ -445,18 +421,6 @@ describe('Sort(Class, Class)', () => {
           new DataTypeUnion('https://schema.org/DataType', [])
         )
       ).toBe(+1);
-
-      // After specific builtins.
-      expect(
-        Sort(
-          new BooleanEnum(
-            'https://schema.org/A',
-            'https://schema.org/B',
-            'https://schema.org/C'
-          ),
-          new DataTypeUnion('https://schema.org/DataType', [])
-        )
-      ).toBe(-1);
     });
 
     it('DataType union is equal', () => {

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -298,48 +298,48 @@ describe('Sort(Class, Class)', () => {
       // Before regular classes.
       expect(
         Sort(
-          new Builtin('https://schema.org/Text', 'string', ''),
+          new Builtin('https://schema.org/Text', 'string'),
           makeClass('https://schema.org/A')
         )
       ).toBe(-1);
       expect(
         Sort(
           makeClass('https://schema.org/A'),
-          new Builtin('https://schema.org/Text', 'string', '')
+          new Builtin('https://schema.org/Text', 'string')
         )
       ).toBe(+1);
 
       // Before regular classes with different domains.
       expect(
         Sort(
-          new Builtin('https://schema.org/Text', 'string', ''),
+          new Builtin('https://schema.org/Text', 'string'),
           makeClass('https://a.org/DataType')
         )
       ).toBe(-1);
       expect(
         Sort(
           makeClass('https://a.org/DataType'),
-          new Builtin('https://schema.org/Text', 'string', '')
+          new Builtin('https://schema.org/Text', 'string')
         )
       ).toBe(+1);
 
       // Before builtins.
       expect(
         Sort(
-          new DataTypeUnion('https://schema.org/DataType', [], ''),
-          new Builtin('https://schema.org/A', 'string', '')
+          new DataTypeUnion('https://schema.org/DataType', []),
+          new Builtin('https://schema.org/A', 'string')
         )
       ).toBe(+1);
       expect(
         Sort(
-          new Builtin('https://schema.org/A', 'string', ''),
-          new DataTypeUnion('https://schema.org/DataType', [], '')
+          new Builtin('https://schema.org/A', 'string'),
+          new DataTypeUnion('https://schema.org/DataType', [])
         )
       ).toBe(-1);
       expect(
         Sort(
-          new Builtin('https://schema.org/Z', 'string', ''),
-          new DataTypeUnion('https://schema.org/DataType', [], '')
+          new Builtin('https://schema.org/Z', 'string'),
+          new DataTypeUnion('https://schema.org/DataType', [])
         )
       ).toBe(-1);
 
@@ -349,73 +349,70 @@ describe('Sort(Class, Class)', () => {
           new BooleanEnum(
             'https://schema.org/Boo',
             'https://schema.org/B',
-            'https://schema.org/C',
-            ''
+            'https://schema.org/C'
           ),
-          new Builtin('https://schema.org/Boo', 'Text', '')
+          new Builtin('https://schema.org/Boo', 'Text')
         )
       ).toBe(0);
 
       // Sorts within Builtins
       expect(
         Sort(
-          new Builtin('https://schema.org/A', 'string', ''),
-          new Builtin('https://schema.org/B', 'string', '')
+          new Builtin('https://schema.org/A', 'string'),
+          new Builtin('https://schema.org/B', 'string')
         )
       ).toBe(-1);
       expect(
         Sort(
-          new Builtin('https://schema.org/A', 'string', ''),
+          new Builtin('https://schema.org/A', 'string'),
           new BooleanEnum(
             'https://schema.org/B',
             'https://schema.org/B',
-            'https://schema.org/C',
-            ''
+            'https://schema.org/C'
           )
         )
       ).toBe(-1);
 
       expect(
         Sort(
-          new Builtin('https://schema.org/B', 'string', ''),
-          new Builtin('https://schema.org/A', 'string', '')
+          new Builtin('https://schema.org/B', 'string'),
+          new Builtin('https://schema.org/A', 'string')
         )
       ).toBe(+1);
       expect(
         Sort(
-          new Builtin('https://schema.org/B', 'string', ''),
+          new Builtin('https://schema.org/B', 'string'),
           new BooleanEnum(
             'https://schema.org/A',
             'https://schema.org/B',
-            'https://schema.org/C',
-            ''
+            'https://schema.org/C'
           )
         )
       ).toBe(+1);
 
       expect(
         Sort(
-          new Builtin('https://schema.org/C', 'string', ''),
-          new Builtin('https://schema.org/C', 'string', '')
+          new Builtin('https://schema.org/C', 'string'),
+          new Builtin('https://schema.org/C', 'string')
         )
       ).toBe(0);
 
       expect(
         Sort(
-          new Builtin('https://schema.org/A#Z', 'string', ''),
-          new Builtin('https://schema.org/C', 'string', '')
+          new Builtin('https://schema.org/A#Z', 'string'),
+          new Builtin('https://schema.org/C', 'string')
         )
       ).toBe(+1);
       expect(
         Sort(
-          new Builtin('https://z.org/C', 'string', ''),
-          new Builtin('https://schema.org/C', 'string', '')
+          new Builtin('https://z.org/C', 'string'),
+          new Builtin('https://schema.org/C', 'string')
         )
       ).toBe(+1);
       expect(
         Sort(
-          new Builtin('https://z.org/Z#A', 'string', ''),
-          new Builtin('https://schema.org/C', 'string', '')
+          new Builtin('https://z.org/Z#A', 'string'),
+          new Builtin('https://schema.org/C', 'string')
         )
       ).toBe(-1);
     });
@@ -424,28 +421,28 @@ describe('Sort(Class, Class)', () => {
       // Before regular classes.
       expect(
         Sort(
-          new DataTypeUnion('https://schema.org/DataType', [], ''),
+          new DataTypeUnion('https://schema.org/DataType', []),
           makeClass('https://schema.org/A')
         )
       ).toBe(-1);
       expect(
         Sort(
           makeClass('https://schema.org/A'),
-          new DataTypeUnion('https://schema.org/DataType', [], '')
+          new DataTypeUnion('https://schema.org/DataType', [])
         )
       ).toBe(+1);
 
       // Before regular classes with different domains.
       expect(
         Sort(
-          new DataTypeUnion('https://schema.org/DataType', [], ''),
+          new DataTypeUnion('https://schema.org/DataType', []),
           makeClass('https://a.org/DataType')
         )
       ).toBe(-1);
       expect(
         Sort(
           makeClass('https://a.org/DataType'),
-          new DataTypeUnion('https://schema.org/DataType', [], '')
+          new DataTypeUnion('https://schema.org/DataType', [])
         )
       ).toBe(+1);
 
@@ -455,10 +452,9 @@ describe('Sort(Class, Class)', () => {
           new BooleanEnum(
             'https://schema.org/A',
             'https://schema.org/B',
-            'https://schema.org/C',
-            ''
+            'https://schema.org/C'
           ),
-          new DataTypeUnion('https://schema.org/DataType', [], '')
+          new DataTypeUnion('https://schema.org/DataType', [])
         )
       ).toBe(-1);
     });
@@ -466,22 +462,22 @@ describe('Sort(Class, Class)', () => {
     it('DataType union is equal', () => {
       expect(
         Sort(
-          new DataTypeUnion('https://schema.org/DataType', [], ''),
-          new DataTypeUnion('https://schema.org/DataType', [], '')
+          new DataTypeUnion('https://schema.org/DataType', []),
+          new DataTypeUnion('https://schema.org/DataType', [])
         )
       ).toBe(0);
 
       expect(
         Sort(
-          new DataTypeUnion('https://schema.org/A', [], ''),
-          new DataTypeUnion('https://schema.org/Z', [], '')
+          new DataTypeUnion('https://schema.org/A', []),
+          new DataTypeUnion('https://schema.org/Z', [])
         )
       ).toBe(0);
 
       expect(
         Sort(
-          new DataTypeUnion('https://schema.org/Z', [], ''),
-          new DataTypeUnion('https://schema.org/A', [], '')
+          new DataTypeUnion('https://schema.org/Z', []),
+          new DataTypeUnion('https://schema.org/A', [])
         )
       ).toBe(0);
     });

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -26,7 +26,7 @@ import {
 import {SchemaString, UrlNode} from '../../src/triples/types';
 import {
   BooleanEnum,
-  Builtin,
+  AliasBuiltin,
   Class,
   DataTypeUnion,
   Sort,
@@ -298,28 +298,28 @@ describe('Sort(Class, Class)', () => {
       // Before regular classes.
       expect(
         Sort(
-          new Builtin('https://schema.org/Text', 'string'),
+          new AliasBuiltin('https://schema.org/Text', 'string'),
           makeClass('https://schema.org/A')
         )
       ).toBe(-1);
       expect(
         Sort(
           makeClass('https://schema.org/A'),
-          new Builtin('https://schema.org/Text', 'string')
+          new AliasBuiltin('https://schema.org/Text', 'string')
         )
       ).toBe(+1);
 
       // Before regular classes with different domains.
       expect(
         Sort(
-          new Builtin('https://schema.org/Text', 'string'),
+          new AliasBuiltin('https://schema.org/Text', 'string'),
           makeClass('https://a.org/DataType')
         )
       ).toBe(-1);
       expect(
         Sort(
           makeClass('https://a.org/DataType'),
-          new Builtin('https://schema.org/Text', 'string')
+          new AliasBuiltin('https://schema.org/Text', 'string')
         )
       ).toBe(+1);
 
@@ -327,18 +327,18 @@ describe('Sort(Class, Class)', () => {
       expect(
         Sort(
           new DataTypeUnion('https://schema.org/DataType', []),
-          new Builtin('https://schema.org/A', 'string')
+          new AliasBuiltin('https://schema.org/A', 'string')
         )
       ).toBe(+1);
       expect(
         Sort(
-          new Builtin('https://schema.org/A', 'string'),
+          new AliasBuiltin('https://schema.org/A', 'string'),
           new DataTypeUnion('https://schema.org/DataType', [])
         )
       ).toBe(-1);
       expect(
         Sort(
-          new Builtin('https://schema.org/Z', 'string'),
+          new AliasBuiltin('https://schema.org/Z', 'string'),
           new DataTypeUnion('https://schema.org/DataType', [])
         )
       ).toBe(-1);
@@ -351,20 +351,20 @@ describe('Sort(Class, Class)', () => {
             'https://schema.org/B',
             'https://schema.org/C'
           ),
-          new Builtin('https://schema.org/Boo', 'Text')
+          new AliasBuiltin('https://schema.org/Boo', 'Text')
         )
       ).toBe(0);
 
       // Sorts within Builtins
       expect(
         Sort(
-          new Builtin('https://schema.org/A', 'string'),
-          new Builtin('https://schema.org/B', 'string')
+          new AliasBuiltin('https://schema.org/A', 'string'),
+          new AliasBuiltin('https://schema.org/B', 'string')
         )
       ).toBe(-1);
       expect(
         Sort(
-          new Builtin('https://schema.org/A', 'string'),
+          new AliasBuiltin('https://schema.org/A', 'string'),
           new BooleanEnum(
             'https://schema.org/B',
             'https://schema.org/B',
@@ -375,13 +375,13 @@ describe('Sort(Class, Class)', () => {
 
       expect(
         Sort(
-          new Builtin('https://schema.org/B', 'string'),
-          new Builtin('https://schema.org/A', 'string')
+          new AliasBuiltin('https://schema.org/B', 'string'),
+          new AliasBuiltin('https://schema.org/A', 'string')
         )
       ).toBe(+1);
       expect(
         Sort(
-          new Builtin('https://schema.org/B', 'string'),
+          new AliasBuiltin('https://schema.org/B', 'string'),
           new BooleanEnum(
             'https://schema.org/A',
             'https://schema.org/B',
@@ -392,27 +392,27 @@ describe('Sort(Class, Class)', () => {
 
       expect(
         Sort(
-          new Builtin('https://schema.org/C', 'string'),
-          new Builtin('https://schema.org/C', 'string')
+          new AliasBuiltin('https://schema.org/C', 'string'),
+          new AliasBuiltin('https://schema.org/C', 'string')
         )
       ).toBe(0);
 
       expect(
         Sort(
-          new Builtin('https://schema.org/A#Z', 'string'),
-          new Builtin('https://schema.org/C', 'string')
+          new AliasBuiltin('https://schema.org/A#Z', 'string'),
+          new AliasBuiltin('https://schema.org/C', 'string')
         )
       ).toBe(+1);
       expect(
         Sort(
-          new Builtin('https://z.org/C', 'string'),
-          new Builtin('https://schema.org/C', 'string')
+          new AliasBuiltin('https://z.org/C', 'string'),
+          new AliasBuiltin('https://schema.org/C', 'string')
         )
       ).toBe(+1);
       expect(
         Sort(
-          new Builtin('https://z.org/Z#A', 'string'),
-          new Builtin('https://schema.org/C', 'string')
+          new AliasBuiltin('https://z.org/Z#A', 'string'),
+          new AliasBuiltin('https://schema.org/C', 'string')
         )
       ).toBe(-1);
     });

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -76,10 +76,7 @@ describe('Class', () => {
       const ctx = new Context();
       ctx.setUrlContext('https://schema.org/');
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonBase = {
-            /** IRI identifying the canonical address of this object. */
-            \\"@id\\"?: string;
-        };
+        "type PersonBase = Partial<IdReference>;
         type PersonLeaf = {
             \\"@type\\": \\"Person\\";
         } & PersonBase;

--- a/test/ts/property_test.ts
+++ b/test/ts/property_test.ts
@@ -54,6 +54,18 @@ describe('PropertyType', () => {
         ).toThrowError('Type expected to be a UrlNode');
       });
 
+      it("type rangeIncludes object fails when class doesn't exist", () => {
+        expect(() =>
+          prop.add(
+            {
+              Predicate: rangeIncludes(),
+              Object: UrlNode.Parse('https://schema.org/Thing'),
+            },
+            new Map()
+          )
+        ).toThrowError('Could not find class for https://schema.org/Thing');
+      });
+
       it('type rangeIncludes object succeeds', () => {
         expect(
           prop.add(
@@ -61,7 +73,7 @@ describe('PropertyType', () => {
               Predicate: rangeIncludes(),
               Object: UrlNode.Parse('https://schema.org/Thing'),
             },
-            new Map()
+            makeClassMap(makeClass('https://schema.org/Thing'))
           )
         ).toBe(true);
       });

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "composite": true
+    "composite": true,
+    "lib": ["ES2015", "ES2019.Array"]
   }
 }


### PR DESCRIPTION
The initial change here ended up pulling a thread that lead to a sequence of other changes and cleanups.

1. Support for **`{"@id": ...}`** references to previously-established objects. This will allow us to unblock `@graph`.
2. Prune `DataType` objects not referenced in ontology (from both defining them as well as including them in the DataType union)
3. Accept context-relative strings for enum values, as well as HTTPS (only when the site is HTTP).

This introduces two breaking changes for `schema-dts-gen` (but **not** in schema-dts):

1. Property parsing is stricter on custom schema where rangeIncludes references a non-existent type.
2. Only types defined in ontology will be included in our class map and output. This means that a reference to e.g. 'Text' or 'DataType' would previously succeed, but now fails.

This also introduces a lot of simplifications:

- DataType union is ever so slightly less special
- Boolean enum is no longer special
- Use real ontology comments when producing comments, rather than wellknown values.