### PR TITLE
Rationalize DataTypes and Fix PronounceableText

### DIFF
--- a/src/transform/toClass.ts
+++ b/src/transform/toClass.ts
@@ -81,13 +81,13 @@ function ForwardDeclareClasses(topics: readonly TypedTopic[]): ClassMap {
       continue;
     } else if (!IsNamedClass(topic)) continue;
 
+    const cls = new Class(topic.Subject);
     const allowString = wellKnownStrings.some(wks =>
       wks.equivTo(topic.Subject)
     );
-    classes.set(
-      topic.Subject.toString(),
-      new Class(topic.Subject, allowString)
-    );
+    if (allowString) cls.addTypedef('string');
+
+    classes.set(topic.Subject.toString(), cls);
   }
 
   return classes;

--- a/test/baselines/nested_datatype_test.ts
+++ b/test/baselines/nested_datatype_test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Baseline tests are a set of tests (in tests/baseline/) that
+ * correspond to full comparisons of a generate .ts output based on a set of
+ * Triples representing an entire ontology.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver';
+
+test(`baseine_${basename(__filename)}`, async () => {
+  const {actual} = await inlineCli(
+    `
+<http://schema.org/name> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+<http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/URL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Text> .
+<http://schema.org/FancyURL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/FancyURL> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/URL> .
+<http://schema.org/PronounceableText> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/PronounceableText> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Text> .
+<http://schema.org/phoneticText> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/phoneticText> <http://schema.org/domainIncludes> <http://schema.org/PronounceableText> .
+<http://schema.org/phoneticText> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+<http://schema.org/ArabicText> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/ArabicText> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/PronounceableText> .
+<http://schema.org/arabicPhoneticText> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/arabicPhoneticText> <http://schema.org/domainIncludes> <http://schema.org/ArabicText> .
+<http://schema.org/arabicPhoneticText> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+<http://schema.org/EnglishText> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/EnglishText> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/PronounceableText> .
+<http://schema.org/website> <http://schema.org/rangeIncludes> <http://schema.org/URL> .
+<http://schema.org/website> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/website> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<http://schema.org/pronunciation> <http://schema.org/rangeIncludes> <http://schema.org/PronounceableText> .
+<http://schema.org/pronunciation> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+<http://schema.org/pronunciation> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+`,
+    ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
+  );
+
+  expect(actual).toMatchInlineSnapshot(`
+    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+    export type WithContext<T extends Thing> = T & {
+        \\"@context\\": \\"https://schema.org\\";
+    };
+
+    type SchemaValue<T> = T | readonly T[];
+    type IdReference = {
+        /** IRI identifying the canonical address of this object. */
+        \\"@id\\": string;
+    };
+
+    export type Text = PronounceableText | URL | string;
+
+    type ArabicTextBase = PronounceableTextBase & {
+        \\"arabicPhoneticText\\"?: SchemaValue<Text>;
+    };
+    type ArabicTextLeaf = {
+        \\"@type\\": \\"ArabicText\\";
+    } & ArabicTextBase;
+    export type ArabicText = ArabicTextLeaf | string;
+
+    type EnglishTextLeaf = {
+        \\"@type\\": \\"EnglishText\\";
+    } & PronounceableTextBase;
+    export type EnglishText = EnglishTextLeaf | string;
+
+    export type FancyURL = string;
+
+    type PronounceableTextBase = Partial<IdReference> & {
+        \\"phoneticText\\"?: SchemaValue<Text>;
+    };
+    type PronounceableTextLeaf = {
+        \\"@type\\": \\"PronounceableText\\";
+    } & PronounceableTextBase;
+    export type PronounceableText = PronounceableTextLeaf | ArabicText | EnglishText | string;
+
+    type ThingBase = Partial<IdReference> & {
+        \\"name\\"?: SchemaValue<Text>;
+        \\"pronunciation\\"?: SchemaValue<PronounceableText | IdReference>;
+        \\"website\\"?: SchemaValue<URL>;
+    };
+    type ThingLeaf = {
+        \\"@type\\": \\"Thing\\";
+    } & ThingBase;
+    export type Thing = ThingLeaf;
+
+    export type URL = FancyURL | string;
+
+    "
+  `);
+});

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -71,7 +71,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    export type Text = string;
+    export type Text = URL | string;
 
     type EntryPointLeaf = {
         \\"@type\\": \\"EntryPoint\\";
@@ -115,7 +115,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 
-    export type URL = Text;
+    export type URL = string;
 
     "
   `);

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -71,7 +71,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    export type Text = string;
+    export type Text = URL | string;
 
     type EntryPointLeaf = {
         \\"@type\\": \\"EntryPoint\\";
@@ -115,7 +115,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 
-    export type URL = Text;
+    export type URL = string;
 
     "
   `);

--- a/test/baselines/url_test.ts
+++ b/test/baselines/url_test.ts
@@ -46,10 +46,10 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    export type Text = string;
+    export type Text = URL | string;
 
     /** Data type: URL. */
-    export type URL = Text;
+    export type URL = string;
 
     "
   `);

--- a/test/helpers/make_class.ts
+++ b/test/helpers/make_class.ts
@@ -16,8 +16,8 @@
 import {UrlNode} from '../../src/triples/types';
 import {Class, ClassMap} from '../../src/ts/class';
 
-export function makeClass(url: string, allowString = false): Class {
-  return new Class(UrlNode.Parse(url), allowString);
+export function makeClass(url: string): Class {
+  return new Class(UrlNode.Parse(url));
 }
 
 export function makeClassMap(...classes: Class[]): ClassMap {

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -70,6 +70,14 @@ describe('Class', () => {
     });
   });
 
+  it("can't add typedef twice", () => {
+    const cls = makeClass('https://schema.org/Person');
+    cls.addTypedef('string');
+    expect(() => cls.addTypedef('Foo')).toThrowError(
+      'already has typedef string'
+    );
+  });
+
   describe('toNode', () => {
     it('by default (no parent)', () => {
       // A class with no parent has a top-level "@id"
@@ -346,7 +354,7 @@ describe('Sort(Class, Class)', () => {
       // Can be same as less specific builtins.
       expect(
         Sort(
-          new Builtin(UrlNode.Parse('https://schema.org/Boo'), false),
+          new Builtin(UrlNode.Parse('https://schema.org/Boo')),
           new AliasBuiltin('https://schema.org/Boo', 'Text')
         )
       ).toBe(0);


### PR DESCRIPTION
Rationalizes our "typedef" datatypes and "allowstring" into a
generalized typedef mechanism.

Restructures inheritance and merging so that, like allowString, these
typedefs are just leaf types.

This allows us to then re-support `PronounceableText`.
