### PR TITLE
Bump version for schema-dts 0.6.1

### DIFF
--- a/dist/schema/package.json
+++ b/dist/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "displayName": "schema-dts: Strongly-typed Schema.org vocabulary declarations",
   "description": "A TypeScript package with latest Schema.org Schema Typings",
   "authors": [


### PR DESCRIPTION
Picks up https://schema.org/version/9.0/