### PR TITLE
Bump schema-dts to 0.7.0 instead.

### DIFF
--- a/dist/schema/package.json
+++ b/dist/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "displayName": "schema-dts: Strongly-typed Schema.org vocabulary declarations",
   "description": "A TypeScript package with latest Schema.org Schema Typings",
   "authors": [


### PR DESCRIPTION
There are actually breaking changes given that we use https now.