### PR TITLE
Mark package as side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "types": "./dist/gen/index.d.ts",
   "main": "./dist/gen/index.js",
   "bin": "./dist/gen/cli/cli.js",
+  "sideEffects": false,
   "devDependencies": {
     "@types/argparse": "^2.0.0",
     "@types/array.prototype.flatmap": "^1.2.2",


### PR DESCRIPTION
Supposedly, this would help with tree shaking in webpack: https://webpack.js.org/guides/tree-shaking/