### PR TITLE
Deprecate Exported Enum Values in JS

### DIFF
--- a/src/ts/enum.ts
+++ b/src/ts/enum.ts
@@ -93,9 +93,13 @@ export class EnumValue {
     return false;
   }
 
+  /** @deprecated Generating Property Assignment nodes for Enums will go away in 0.8.0. */
   toNode() {
     return withComments(
-      this.comment,
+      this.comment +
+        `\n@deprecated Please use the literal string "${toEnumName(
+          this.value
+        )}" instead.`,
       createPropertyAssignment(
         toEnumName(this.value),
         createAsExpression(

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -72,8 +72,15 @@ test(`baseine_${basename(__filename)}`, async () => {
      */
     export type Thing = \\"http://schema.org/Gadget\\" | \\"https://schema.org/Gadget\\" | \\"Gadget\\" | \\"http://schema.org/Widget\\" | \\"https://schema.org/Widget\\" | \\"Widget\\" | ThingLeaf;
     export const Thing = {
-        /** Complex! */
+        /**
+         * Complex!
+         * @deprecated Please use the literal string \\"Gadget\\" instead.
+         */
         Gadget: (\\"http://schema.org/Gadget\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"Widget\\" instead.
+         */
         Widget: (\\"http://schema.org/Widget\\" as const)
     };
 

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -57,12 +57,35 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** A Thing! */
     export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | \\"https://schema.org/e\\" | \\"e\\" | \\"http://google.com/f\\" | \\"https://google.com/f\\" | ThingLeaf;
     export const Thing = {
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"a\\" instead.
+         */
         a: (\\"http://schema.org/a\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"b\\" instead.
+         */
         b: (\\"http://schema.org/b\\" as const),
-        /** A letter! */
+        /**
+         * A letter!
+         * @deprecated Please use the literal string \\"c\\" instead.
+         */
         c: (\\"http://schema.org/c\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"d\\" instead.
+         */
         d: (\\"http://schema.org/d\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"e\\" instead.
+         */
         e: (\\"https://schema.org/e\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"f\\" instead.
+         */
         f: (\\"http://google.com/f\\" as const)
     };
 

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -54,10 +54,25 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** A Thing! */
     export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | ThingLeaf;
     export const Thing = {
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"a\\" instead.
+         */
         a: (\\"http://schema.org/a\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"b\\" instead.
+         */
         b: (\\"http://schema.org/b\\" as const),
-        /** A letter! */
+        /**
+         * A letter!
+         * @deprecated Please use the literal string \\"c\\" instead.
+         */
         c: (\\"http://schema.org/c\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"d\\" instead.
+         */
         d: (\\"http://schema.org/d\\" as const)
     };
 

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -65,7 +65,15 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Boolean = \\"http://schema.org/False\\" | \\"https://schema.org/False\\" | \\"False\\" | \\"http://schema.org/True\\" | \\"https://schema.org/True\\" | \\"True\\" | boolean;
     export const Boolean = {
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"False\\" instead.
+         */
         False: (\\"http://schema.org/False\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"True\\" instead.
+         */
         True: (\\"http://schema.org/True\\" as const)
     };
 

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -85,7 +85,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"https://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
-        /** A type of medical procedure that involves invasive surgical techniques. */
+        /**
+         * A type of medical procedure that involves invasive surgical techniques.
+         * @deprecated Please use the literal string \\"SurgicalProcedure\\" instead.
+         */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
     };
 

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -85,7 +85,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"https://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
-        /** A type of medical procedure that involves invasive surgical techniques. */
+        /**
+         * A type of medical procedure that involves invasive surgical techniques.
+         * @deprecated Please use the literal string \\"SurgicalProcedure\\" instead.
+         */
         SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
     };
 

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -122,7 +122,15 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** An enumeration that describes different types of medical procedures. */
     export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"https://schema.org/NoninvasiveProcedure\\" | \\"NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | \\"https://schema.org/PercutaneousProcedure\\" | \\"PercutaneousProcedure\\" | MedicalProcedureTypeLeaf;
     export const MedicalProcedureType = {
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"NoninvasiveProcedure\\" instead.
+         */
         NoninvasiveProcedure: (\\"http://schema.org/NoninvasiveProcedure\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"PercutaneousProcedure\\" instead.
+         */
         PercutaneousProcedure: (\\"http://schema.org/PercutaneousProcedure\\" as const)
     };
 
@@ -143,7 +151,15 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & PhysicalExamBase;
     export type PhysicalExam = \\"http://schema.org/Head\\" | \\"https://schema.org/Head\\" | \\"Head\\" | \\"http://schema.org/Neuro\\" | \\"https://schema.org/Neuro\\" | \\"Neuro\\" | PhysicalExamLeaf;
     export const PhysicalExam = {
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"Head\\" instead.
+         */
         Head: (\\"http://schema.org/Head\\" as const),
+        /**
+         * undefined
+         * @deprecated Please use the literal string \\"Neuro\\" instead.
+         */
         Neuro: (\\"http://schema.org/Neuro\\" as const)
     };
 


### PR DESCRIPTION
See #131 for a justification/discussion.

We'd rather users use:

```ts
const kneeReplacement: MedicalProcedure = {
  "@type": "MedicalProcedure",
  "procedureType": "PercutaneousProcedure", // or "https://schema.org/PercutaneousProcedure"
};
```

We already accept these as constant string literals, but now we'll remove the alternative, such as:

```
MedicalProcedureType.PercutaneousProcedure
```