### PR TITLE
Clean Enum output

### DIFF
--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -346,29 +346,6 @@ export class Class {
     }
   }
 
-  private enumDecl(): VariableStatement | undefined {
-    if (this._enums.size === 0) return undefined;
-    const enums = this.enums();
-
-    return factory.createVariableStatement(
-      factory.createModifiersFromModifierFlags(ModifierFlags.Export),
-      factory.createVariableDeclarationList(
-        [
-          factory.createVariableDeclaration(
-            this.className(),
-            /*exclamationToken=*/ undefined,
-            /*type=*/ undefined,
-            factory.createObjectLiteralExpression(
-              enums.map(e => e.toNode()),
-              /*multiLine=*/ true
-            )
-          ),
-        ],
-        NodeFlags.Const
-      )
-    );
-  }
-
   toNode(context: Context, skipDeprecated: boolean): readonly Statement[] {
     const typeValue: TypeNode = this.totalType(context, skipDeprecated);
     const declaration = withComments(
@@ -395,18 +372,11 @@ export class Class {
     // export type Xyz = "Enum1"|"Enum2"|...        // Enum Piece: Optional.
     //                  |XyzLeaf                    // 'Leaf' Piece.
     //                  |Child1|Child2|...          // Child Piece: Optional.
-    // // Enum Values: Optional --------------------//
-    // export const Xyz = {
-    //   Enum1 = "Enum1" as const,
-    //   Enum2 = "Enum2" as const,
-    //   ...
-    // }
     // //-------------------------------------------//
     return arrayOf<Statement>(
       this.baseDecl(skipDeprecated, context),
       this.leafDecl(context),
-      declaration,
-      this.enumDecl()
+      declaration
     );
   }
 }

--- a/src/ts/enum.ts
+++ b/src/ts/enum.ts
@@ -20,8 +20,6 @@ import {ObjectPredicate, TSubject, TTypeName} from '../triples/triple';
 import {GetComment, IsClassType, IsDataType} from '../triples/wellKnown';
 
 import {ClassMap} from './class';
-import {withComments} from './util/comments';
-import {toEnumName} from './util/names';
 import {Context} from './context';
 
 /**
@@ -84,23 +82,6 @@ export class EnumValue {
     }
 
     return false;
-  }
-
-  /** @deprecated Generating Property Assignment nodes for Enums will go away in 0.8.0. */
-  toNode() {
-    return withComments(
-      this.comment +
-        `\n@deprecated Please use the literal string "${toEnumName(
-          this.value
-        )}" instead.`,
-      factory.createPropertyAssignment(
-        toEnumName(this.value),
-        factory.createAsExpression(
-          factory.createStringLiteral(this.value.toString()),
-          factory.createTypeReferenceNode('const', undefined)
-        )
-      )
-    );
   }
 
   toTypeLiteral(context: Context): TypeNode[] {

--- a/src/ts/util/names.ts
+++ b/src/ts/util/names.ts
@@ -33,7 +33,3 @@ export function toClassName(subject: TTypeName): string {
 
   return sanitizedName;
 }
-
-export function toEnumName(subject: TSubject): string {
-  return subject.name.replace(/[^A-Za-z0-9_]/g, '_');
-}

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -74,18 +74,6 @@ test(`baseine_${basename(__filename)}`, async () => {
      * - _Baz_, and __Bat__
      */
     export type Thing = \\"http://schema.org/Gadget\\" | \\"https://schema.org/Gadget\\" | \\"Gadget\\" | \\"http://schema.org/Widget\\" | \\"https://schema.org/Widget\\" | \\"Widget\\" | ThingLeaf;
-    export const Thing = {
-        /**
-         * Complex!
-         * @deprecated Please use the literal string \\"Gadget\\" instead.
-         */
-        Gadget: (\\"http://schema.org/Gadget\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"Widget\\" instead.
-         */
-        Widget: (\\"http://schema.org/Widget\\" as const)
-    };
 
     "
   `);

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -59,38 +59,6 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     /** A Thing! */
     export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | \\"https://schema.org/e\\" | \\"e\\" | \\"http://google.com/f\\" | \\"https://google.com/f\\" | ThingLeaf;
-    export const Thing = {
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"a\\" instead.
-         */
-        a: (\\"http://schema.org/a\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"b\\" instead.
-         */
-        b: (\\"http://schema.org/b\\" as const),
-        /**
-         * A letter!
-         * @deprecated Please use the literal string \\"c\\" instead.
-         */
-        c: (\\"http://schema.org/c\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"d\\" instead.
-         */
-        d: (\\"http://schema.org/d\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"e\\" instead.
-         */
-        e: (\\"https://schema.org/e\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"f\\" instead.
-         */
-        f: (\\"http://google.com/f\\" as const)
-    };
 
     "
   `);

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -56,28 +56,6 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     /** A Thing! */
     export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | ThingLeaf;
-    export const Thing = {
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"a\\" instead.
-         */
-        a: (\\"http://schema.org/a\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"b\\" instead.
-         */
-        b: (\\"http://schema.org/b\\" as const),
-        /**
-         * A letter!
-         * @deprecated Please use the literal string \\"c\\" instead.
-         */
-        c: (\\"http://schema.org/c\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"d\\" instead.
-         */
-        d: (\\"http://schema.org/d\\" as const)
-    };
 
     "
   `);

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -67,18 +67,6 @@ test(`baseine_${basename(__filename)}`, async () => {
     };
 
     export type Boolean = \\"http://schema.org/False\\" | \\"https://schema.org/False\\" | \\"False\\" | \\"http://schema.org/True\\" | \\"https://schema.org/True\\" | \\"True\\" | boolean;
-    export const Boolean = {
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"False\\" instead.
-         */
-        False: (\\"http://schema.org/False\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"True\\" instead.
-         */
-        True: (\\"http://schema.org/True\\" as const)
-    };
 
     export type Date = string;
 

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -87,13 +87,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & ThingBase;
     export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"https://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
-    export const MedicalProcedureType = {
-        /**
-         * A type of medical procedure that involves invasive surgical techniques.
-         * @deprecated Please use the literal string \\"SurgicalProcedure\\" instead.
-         */
-        SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
-    };
 
     type SurgicalProcedureLeaf = {
         \\"@type\\": \\"SurgicalProcedure\\";

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -87,13 +87,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"MedicalProcedureType\\";
     } & ThingBase;
     export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"https://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
-    export const MedicalProcedureType = {
-        /**
-         * A type of medical procedure that involves invasive surgical techniques.
-         * @deprecated Please use the literal string \\"SurgicalProcedure\\" instead.
-         */
-        SurgicalProcedure: (\\"http://schema.org/SurgicalProcedure\\" as const)
-    };
 
     type SurgicalProcedureLeaf = {
         \\"@type\\": \\"SurgicalProcedure\\";

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -124,18 +124,6 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     /** An enumeration that describes different types of medical procedures. */
     export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"https://schema.org/NoninvasiveProcedure\\" | \\"NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | \\"https://schema.org/PercutaneousProcedure\\" | \\"PercutaneousProcedure\\" | MedicalProcedureTypeLeaf;
-    export const MedicalProcedureType = {
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"NoninvasiveProcedure\\" instead.
-         */
-        NoninvasiveProcedure: (\\"http://schema.org/NoninvasiveProcedure\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"PercutaneousProcedure\\" instead.
-         */
-        PercutaneousProcedure: (\\"http://schema.org/PercutaneousProcedure\\" as const)
-    };
 
     type MedicalTherapyLeaf = {
         \\"@type\\": \\"MedicalTherapy\\";
@@ -153,18 +141,6 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@type\\": \\"PhysicalExam\\";
     } & PhysicalExamBase;
     export type PhysicalExam = \\"http://schema.org/Head\\" | \\"https://schema.org/Head\\" | \\"Head\\" | \\"http://schema.org/Neuro\\" | \\"https://schema.org/Neuro\\" | \\"Neuro\\" | PhysicalExamLeaf;
-    export const PhysicalExam = {
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"Head\\" instead.
-         */
-        Head: (\\"http://schema.org/Head\\" as const),
-        /**
-         * undefined
-         * @deprecated Please use the literal string \\"Neuro\\" instead.
-         */
-        Neuro: (\\"http://schema.org/Neuro\\" as const)
-    };
 
     type SurgicalProcedureLeaf = {
         \\"@type\\": \\"SurgicalProcedure\\";


### PR DESCRIPTION
This is a backwards-incompatible change (slated for 0.8.0).

Finally fixes #131 