### PR TITLE
Migrate Some Type Literals to Interfaces

### DIFF
--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -18,7 +18,6 @@ import {
   DeclarationStatement,
   ModifierFlags,
   Statement,
-  TypeAliasDeclaration,
   TypeNode,
   SyntaxKind,
   InterfaceDeclaration,
@@ -265,7 +264,7 @@ export class Class {
     );
   }
 
-  protected leafDecl(context: Context): TypeAliasDeclaration | undefined {
+  protected leafDecl(context: Context): InterfaceDeclaration | undefined {
     const leafName = this.leafName();
     if (!leafName) return undefined;
 
@@ -280,19 +279,20 @@ export class Class {
       /*typeArguments=*/ []
     );
 
-    const thisType = factory.createIntersectionTypeNode([
-      factory.createTypeLiteralNode([
-        new TypeProperty(this.subject).toNode(context),
-      ]),
-      baseTypeReference,
-    ]);
-
-    return factory.createTypeAliasDeclaration(
+    return factory.createInterfaceDeclaration(
       /*decorators=*/ [],
       /*modifiers=*/ [],
       leafName,
       /*typeParameters=*/ [],
-      thisType
+      /*heritage=*/ [
+        factory.createHeritageClause(SyntaxKind.ExtendsKeyword, [
+          factory.createExpressionWithTypeArguments(
+            factory.createIdentifier(baseName),
+            /*typeArguments=*/ []
+          ),
+        ]),
+      ],
+      /*members=*/ [new TypeProperty(this.subject).toNode(context)]
     );
   }
 

--- a/src/ts/class.ts
+++ b/src/ts/class.ts
@@ -17,11 +17,11 @@ import {
   factory,
   DeclarationStatement,
   ModifierFlags,
-  NodeFlags,
   Statement,
   TypeAliasDeclaration,
   TypeNode,
-  VariableStatement,
+  SyntaxKind,
+  InterfaceDeclaration,
 } from 'typescript';
 
 import {Log} from '../logging';
@@ -219,62 +219,49 @@ export class Class {
     return this.namedParents().length === 1 && this._props.size === 0;
   }
 
-  private baseNode(
+  private baseDecl(
     skipDeprecatedProperties: boolean,
     context: Context
-  ): TypeNode | undefined {
+  ): InterfaceDeclaration | undefined {
     if (this.skipBase()) {
       return undefined;
     }
 
-    const parentTypes = this.namedParents().map(p =>
-      factory.createTypeReferenceNode(p, [])
-    );
-    const parentNode =
-      parentTypes.length === 0
-        ? factory.createTypeReferenceNode('Partial', [
-            factory.createTypeReferenceNode(
-              IdReferenceName,
-              /*typeArguments=*/ []
-            ),
-          ])
-        : parentTypes.length === 1
-        ? parentTypes[0]
-        : factory.createParenthesizedType(
-            factory.createIntersectionTypeNode(parentTypes)
-          );
-
-    // Properties part.
-    const propLiteral = factory.createTypeLiteralNode([
-      // ... then everything else.
-      ...this.properties()
-        .filter(property => !property.deprecated || !skipDeprecatedProperties)
-        .map(prop => prop.toNode(context)),
-    ]);
-
-    if (propLiteral.members.length > 0) {
-      return factory.createIntersectionTypeNode([parentNode, propLiteral]);
-    } else {
-      return parentNode;
-    }
-  }
-
-  private baseDecl(
-    skipDeprecatedProperties: boolean,
-    context: Context
-  ): TypeAliasDeclaration | undefined {
-    const baseNode = this.baseNode(skipDeprecatedProperties, context);
-
-    if (!baseNode) return undefined;
     const baseName = this.baseName();
     assert(baseName, 'If a baseNode is defined, baseName must be defined.');
 
-    return factory.createTypeAliasDeclaration(
+    const parentTypes = this.namedParents().map(p =>
+      factory.createExpressionWithTypeArguments(factory.createIdentifier(p), [])
+    );
+
+    const heritage = factory.createHeritageClause(
+      SyntaxKind.ExtendsKeyword,
+      parentTypes.length === 0
+        ? [
+            factory.createExpressionWithTypeArguments(
+              factory.createIdentifier('Partial'),
+              /*typeArguments=*/ [
+                factory.createTypeReferenceNode(
+                  IdReferenceName,
+                  /*typeArguments=*/ []
+                ),
+              ]
+            ),
+          ]
+        : parentTypes
+    );
+
+    const members = this.properties()
+      .filter(property => !property.deprecated || !skipDeprecatedProperties)
+      .map(prop => prop.toNode(context));
+
+    return factory.createInterfaceDeclaration(
       /*decorators=*/ [],
       /*modifiers=*/ [],
       baseName,
       /*typeParameters=*/ [],
-      baseNode
+      /*heritageClause=*/ [heritage],
+      /*members=*/ members
     );
   }
 

--- a/test/baselines/category_test.ts
+++ b/test/baselines/category_test.ts
@@ -63,9 +63,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** A distillery. */
     export type Distillery = DistilleryLeaf;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/category_test.ts
+++ b/test/baselines/category_test.ts
@@ -57,18 +57,18 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type DistilleryLeaf = {
+    interface DistilleryLeaf extends ThingBase {
         \\"@type\\": \\"Distillery\\";
-    } & ThingBase;
+    }
     /** A distillery. */
     export type Distillery = DistilleryLeaf;
 
     interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | Distillery;
 
     "

--- a/test/baselines/comments_test.ts
+++ b/test/baselines/comments_test.ts
@@ -70,9 +70,9 @@ test(`baseine_${basename(__filename)}`, async () => {
         /** Names are great! {@link X Y} */
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     /**
      * Things are amazing!
      *

--- a/test/baselines/comments_test.ts
+++ b/test/baselines/comments_test.ts
@@ -59,7 +59,7 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** Data type: Text. */
     export type Text = string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         /**
          * Reminds me of this quote:
          * \`FooBar\`
@@ -69,7 +69,7 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"knows\\"?: SchemaValue<Text>;
         /** Names are great! {@link X Y} */
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/data_type_union_test.ts
+++ b/test/baselines/data_type_union_test.ts
@@ -64,10 +64,10 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** The basic data types such as Integers, Strings, etc. */
     export type DataType = Number | Text;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"age\\"?: SchemaValue<Number>;
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/data_type_union_test.ts
+++ b/test/baselines/data_type_union_test.ts
@@ -68,9 +68,9 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"age\\"?: SchemaValue<Number>;
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf;
 
     "

--- a/test/baselines/default_ontology_test.ts
+++ b/test/baselines/default_ontology_test.ts
@@ -44,7 +44,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    type ThingBase = Partial<IdReference>;
+    interface ThingBase extends Partial<IdReference> {
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/default_ontology_test.ts
+++ b/test/baselines/default_ontology_test.ts
@@ -46,9 +46,9 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     interface ThingBase extends Partial<IdReference> {
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf;
 
     "

--- a/test/baselines/deprecated_objects_test.ts
+++ b/test/baselines/deprecated_objects_test.ts
@@ -82,17 +82,17 @@ test(`baseine_${basename(__filename)}`, async () => {
     interface CarBase extends ThingBase {
         \\"doorNumber\\"?: SchemaValue<Number>;
     }
-    type CarLeaf = {
+    interface CarLeaf extends CarBase {
         \\"@type\\": \\"Car\\";
-    } & CarBase;
+    }
     export type Car = CarLeaf;
 
     interface PersonLikeBase extends ThingBase {
         \\"height\\"?: SchemaValue<Number>;
     }
-    type PersonLikeLeaf = {
+    interface PersonLikeLeaf extends PersonLikeBase {
         \\"@type\\": \\"PersonLike\\";
-    } & PersonLikeBase;
+    }
     export type PersonLike = PersonLikeLeaf;
 
     interface ThingBase extends Partial<IdReference> {
@@ -103,9 +103,9 @@ test(`baseine_${basename(__filename)}`, async () => {
          */
         \\"names\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | Car | PersonLike | Vehicle;
 
     interface VehicleBase extends ThingBase {
@@ -113,9 +113,9 @@ test(`baseine_${basename(__filename)}`, async () => {
         /** @deprecated Consider using http://schema.org/doorNumber instead. */
         \\"doors\\"?: SchemaValue<Number>;
     }
-    type VehicleLeaf = {
+    interface VehicleLeaf extends VehicleBase {
         \\"@type\\": \\"Vehicle\\";
-    } & VehicleBase;
+    }
     /** @deprecated Use Car instead. */
     export type Vehicle = VehicleLeaf;
 

--- a/test/baselines/deprecated_objects_test.ts
+++ b/test/baselines/deprecated_objects_test.ts
@@ -79,40 +79,40 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type CarBase = ThingBase & {
+    interface CarBase extends ThingBase {
         \\"doorNumber\\"?: SchemaValue<Number>;
-    };
+    }
     type CarLeaf = {
         \\"@type\\": \\"Car\\";
     } & CarBase;
     export type Car = CarLeaf;
 
-    type PersonLikeBase = ThingBase & {
+    interface PersonLikeBase extends ThingBase {
         \\"height\\"?: SchemaValue<Number>;
-    };
+    }
     type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
     } & PersonLikeBase;
     export type PersonLike = PersonLikeLeaf;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
         /**
          * Names are great! {@link X Y}
          * @deprecated Consider using http://schema.org/name or http://schema.org/height instead.
          */
         \\"names\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     export type Thing = ThingLeaf | Car | PersonLike | Vehicle;
 
-    type VehicleBase = ThingBase & {
+    interface VehicleBase extends ThingBase {
         \\"doorNumber\\"?: SchemaValue<Number>;
         /** @deprecated Consider using http://schema.org/doorNumber instead. */
         \\"doors\\"?: SchemaValue<Number>;
-    };
+    }
     type VehicleLeaf = {
         \\"@type\\": \\"Vehicle\\";
     } & VehicleBase;

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -59,10 +59,10 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         /** Names are great! {@link X Y} */
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/duplicate_comments_test.ts
+++ b/test/baselines/duplicate_comments_test.ts
@@ -63,9 +63,9 @@ test(`baseine_${basename(__filename)}`, async () => {
         /** Names are great! {@link X Y} */
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     /**
      * Things are amazing!
      *

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -53,7 +53,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    type ThingBase = Partial<IdReference>;
+    interface ThingBase extends Partial<IdReference> {
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/enum_skipped_test.ts
+++ b/test/baselines/enum_skipped_test.ts
@@ -55,9 +55,9 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     interface ThingBase extends Partial<IdReference> {
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     /** A Thing! */
     export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | \\"https://schema.org/e\\" | \\"e\\" | \\"http://google.com/f\\" | \\"https://google.com/f\\" | ThingLeaf;
 

--- a/test/baselines/inheritance_multiple_test.ts
+++ b/test/baselines/inheritance_multiple_test.ts
@@ -65,25 +65,25 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type PersonLikeBase = ThingBase & {
+    interface PersonLikeBase extends ThingBase {
         \\"height\\"?: SchemaValue<Number>;
-    };
+    }
     type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
     } & PersonLikeBase;
     export type PersonLike = PersonLikeLeaf;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;
     export type Thing = ThingLeaf | PersonLike | Vehicle;
 
-    type VehicleBase = ThingBase & {
+    interface VehicleBase extends ThingBase {
         \\"doors\\"?: SchemaValue<Number>;
-    };
+    }
     type VehicleLeaf = {
         \\"@type\\": \\"Vehicle\\";
     } & VehicleBase;

--- a/test/baselines/inheritance_multiple_test.ts
+++ b/test/baselines/inheritance_multiple_test.ts
@@ -68,25 +68,25 @@ test(`baseine_${basename(__filename)}`, async () => {
     interface PersonLikeBase extends ThingBase {
         \\"height\\"?: SchemaValue<Number>;
     }
-    type PersonLikeLeaf = {
+    interface PersonLikeLeaf extends PersonLikeBase {
         \\"@type\\": \\"PersonLike\\";
-    } & PersonLikeBase;
+    }
     export type PersonLike = PersonLikeLeaf;
 
     interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | PersonLike | Vehicle;
 
     interface VehicleBase extends ThingBase {
         \\"doors\\"?: SchemaValue<Number>;
     }
-    type VehicleLeaf = {
+    interface VehicleLeaf extends VehicleBase {
         \\"@type\\": \\"Vehicle\\";
-    } & VehicleBase;
+    }
     export type Vehicle = VehicleLeaf;
 
     "

--- a/test/baselines/inheritance_one_test.ts
+++ b/test/baselines/inheritance_one_test.ts
@@ -63,17 +63,17 @@ test(`baseine_${basename(__filename)}`, async () => {
     interface PersonLikeBase extends ThingBase {
         \\"height\\"?: SchemaValue<Number>;
     }
-    type PersonLikeLeaf = {
+    interface PersonLikeLeaf extends PersonLikeBase {
         \\"@type\\": \\"PersonLike\\";
-    } & PersonLikeBase;
+    }
     export type PersonLike = PersonLikeLeaf;
 
     interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | PersonLike;
 
     "

--- a/test/baselines/inheritance_one_test.ts
+++ b/test/baselines/inheritance_one_test.ts
@@ -60,17 +60,17 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type PersonLikeBase = ThingBase & {
+    interface PersonLikeBase extends ThingBase {
         \\"height\\"?: SchemaValue<Number>;
-    };
+    }
     type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
     } & PersonLikeBase;
     export type PersonLike = PersonLikeLeaf;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/nested_datatype_test.ts
+++ b/test/baselines/nested_datatype_test.ts
@@ -76,14 +76,14 @@ test(`baseine_${basename(__filename)}`, async () => {
     interface ArabicTextBase extends PronounceableTextBase {
         \\"arabicPhoneticText\\"?: SchemaValue<Text>;
     }
-    type ArabicTextLeaf = {
+    interface ArabicTextLeaf extends ArabicTextBase {
         \\"@type\\": \\"ArabicText\\";
-    } & ArabicTextBase;
+    }
     export type ArabicText = ArabicTextLeaf | string;
 
-    type EnglishTextLeaf = {
+    interface EnglishTextLeaf extends PronounceableTextBase {
         \\"@type\\": \\"EnglishText\\";
-    } & PronounceableTextBase;
+    }
     export type EnglishText = EnglishTextLeaf | string;
 
     export type FancyURL = string;
@@ -91,9 +91,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     interface PronounceableTextBase extends Partial<IdReference> {
         \\"phoneticText\\"?: SchemaValue<Text>;
     }
-    type PronounceableTextLeaf = {
+    interface PronounceableTextLeaf extends PronounceableTextBase {
         \\"@type\\": \\"PronounceableText\\";
-    } & PronounceableTextBase;
+    }
     export type PronounceableText = PronounceableTextLeaf | ArabicText | EnglishText | string;
 
     interface ThingBase extends Partial<IdReference> {
@@ -101,9 +101,9 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"pronunciation\\"?: SchemaValue<PronounceableText | IdReference>;
         \\"website\\"?: SchemaValue<URL>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf;
 
     export type URL = FancyURL | string;

--- a/test/baselines/nested_datatype_test.ts
+++ b/test/baselines/nested_datatype_test.ts
@@ -73,9 +73,9 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = PronounceableText | URL | string;
 
-    type ArabicTextBase = PronounceableTextBase & {
+    interface ArabicTextBase extends PronounceableTextBase {
         \\"arabicPhoneticText\\"?: SchemaValue<Text>;
-    };
+    }
     type ArabicTextLeaf = {
         \\"@type\\": \\"ArabicText\\";
     } & ArabicTextBase;
@@ -88,19 +88,19 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type FancyURL = string;
 
-    type PronounceableTextBase = Partial<IdReference> & {
+    interface PronounceableTextBase extends Partial<IdReference> {
         \\"phoneticText\\"?: SchemaValue<Text>;
-    };
+    }
     type PronounceableTextLeaf = {
         \\"@type\\": \\"PronounceableText\\";
     } & PronounceableTextBase;
     export type PronounceableText = PronounceableTextLeaf | ArabicText | EnglishText | string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
         \\"pronunciation\\"?: SchemaValue<PronounceableText | IdReference>;
         \\"website\\"?: SchemaValue<URL>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/nodeprecated_objects_test.ts
+++ b/test/baselines/nodeprecated_objects_test.ts
@@ -86,25 +86,25 @@ test(`baseine_${basename(__filename)}`, async () => {
     interface CarBase extends ThingBase {
         \\"doorNumber\\"?: SchemaValue<Number>;
     }
-    type CarLeaf = {
+    interface CarLeaf extends CarBase {
         \\"@type\\": \\"Car\\";
-    } & CarBase;
+    }
     export type Car = CarLeaf;
 
     interface PersonLikeBase extends ThingBase {
         \\"height\\"?: SchemaValue<Number>;
     }
-    type PersonLikeLeaf = {
+    interface PersonLikeLeaf extends PersonLikeBase {
         \\"@type\\": \\"PersonLike\\";
-    } & PersonLikeBase;
+    }
     export type PersonLike = PersonLikeLeaf;
 
     interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | Car | PersonLike;
 
     "

--- a/test/baselines/nodeprecated_objects_test.ts
+++ b/test/baselines/nodeprecated_objects_test.ts
@@ -83,25 +83,25 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type CarBase = ThingBase & {
+    interface CarBase extends ThingBase {
         \\"doorNumber\\"?: SchemaValue<Number>;
-    };
+    }
     type CarLeaf = {
         \\"@type\\": \\"Car\\";
     } & CarBase;
     export type Car = CarLeaf;
 
-    type PersonLikeBase = ThingBase & {
+    interface PersonLikeBase extends ThingBase {
         \\"height\\"?: SchemaValue<Number>;
-    };
+    }
     type PersonLikeLeaf = {
         \\"@type\\": \\"PersonLike\\";
     } & PersonLikeBase;
     export type PersonLike = PersonLikeLeaf;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/property_edge_cases_test.ts
+++ b/test/baselines/property_edge_cases_test.ts
@@ -58,9 +58,9 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"knows\\"?: SchemaValue<never>;
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf;
 
     "

--- a/test/baselines/property_edge_cases_test.ts
+++ b/test/baselines/property_edge_cases_test.ts
@@ -54,10 +54,10 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"knows\\"?: SchemaValue<never>;
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -65,42 +65,42 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type DistanceLeaf = {
+    interface DistanceLeaf extends ThingBase {
         \\"@type\\": \\"Distance\\";
-    } & ThingBase;
+    }
     export type Distance = DistanceLeaf | string;
 
-    type DurationLeaf = {
+    interface DurationLeaf extends ThingBase {
         \\"@type\\": \\"Duration\\";
-    } & ThingBase;
+    }
     export type Duration = DurationLeaf | string;
 
-    type EnergyLeaf = {
+    interface EnergyLeaf extends ThingBase {
         \\"@type\\": \\"Energy\\";
-    } & ThingBase;
+    }
     export type Energy = EnergyLeaf | string;
 
-    type IntangibleLeaf = {
+    interface IntangibleLeaf extends ThingBase {
         \\"@type\\": \\"Intangible\\";
-    } & ThingBase;
+    }
     export type Intangible = IntangibleLeaf | Quantity;
 
-    type MassLeaf = {
+    interface MassLeaf extends ThingBase {
         \\"@type\\": \\"Mass\\";
-    } & ThingBase;
+    }
     export type Mass = MassLeaf | string;
 
-    type QuantityLeaf = {
+    interface QuantityLeaf extends ThingBase {
         \\"@type\\": \\"Quantity\\";
-    } & ThingBase;
+    }
     export type Quantity = QuantityLeaf | Distance | Duration | Energy | Mass | string;
 
     interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | Intangible;
 
     "

--- a/test/baselines/quantities_test.ts
+++ b/test/baselines/quantities_test.ts
@@ -95,9 +95,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type Quantity = QuantityLeaf | Distance | Duration | Energy | Mass | string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/simple_test.ts
+++ b/test/baselines/simple_test.ts
@@ -54,9 +54,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf;
 
     "

--- a/test/baselines/simple_test.ts
+++ b/test/baselines/simple_test.ts
@@ -51,9 +51,9 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -52,9 +52,9 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     interface ThingBase extends Partial<IdReference> {
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     /** A Thing! */
     export type Thing = \\"http://schema.org/a\\" | \\"https://schema.org/a\\" | \\"a\\" | \\"http://schema.org/b\\" | \\"https://schema.org/b\\" | \\"b\\" | \\"http://schema.org/c\\" | \\"https://schema.org/c\\" | \\"c\\" | \\"http://schema.org/d\\" | \\"https://schema.org/d\\" | \\"d\\" | ThingLeaf;
 

--- a/test/baselines/sorted_enum_test.ts
+++ b/test/baselines/sorted_enum_test.ts
@@ -50,7 +50,8 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    type ThingBase = Partial<IdReference>;
+    interface ThingBase extends Partial<IdReference> {
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/sorted_props_test.ts
+++ b/test/baselines/sorted_props_test.ts
@@ -60,12 +60,12 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"a\\"?: SchemaValue<Text>;
         \\"b\\"?: SchemaValue<Text>;
         \\"c\\"?: SchemaValue<Text>;
         \\"d\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/sorted_props_test.ts
+++ b/test/baselines/sorted_props_test.ts
@@ -66,9 +66,9 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"c\\"?: SchemaValue<Text>;
         \\"d\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf;
 
     "

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -78,9 +78,9 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Time = string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"a\\"?: SchemaValue<Boolean | Date | DateTime | Number | Text | Time>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/sorted_proptypes_test.ts
+++ b/test/baselines/sorted_proptypes_test.ts
@@ -81,9 +81,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     interface ThingBase extends Partial<IdReference> {
         \\"a\\"?: SchemaValue<Boolean | Date | DateTime | Number | Text | Time>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf;
 
     "

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -81,20 +81,20 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type EntryPoint = EntryPointLeaf | string;
 
-    type OrganizationBase = ThingBase & {
+    interface OrganizationBase extends ThingBase {
         \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
         \\"owner\\"?: SchemaValue<Person | IdReference>;
         \\"urlTemplate\\"?: SchemaValue<URL>;
-    };
+    }
     type OrganizationLeaf = {
         \\"@type\\": \\"Organization\\";
     } & OrganizationBase;
     export type Organization = OrganizationLeaf | string;
 
-    type PersonBase = ThingBase & {
+    interface PersonBase extends ThingBase {
         \\"height\\"?: SchemaValue<Quantity | IdReference>;
         \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
-    };
+    }
     type PersonLeaf = {
         \\"@type\\": \\"Person\\";
     } & PersonBase;
@@ -110,9 +110,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type Quantity = QuantityLeaf | string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/stringlike_http_test.ts
+++ b/test/baselines/stringlike_http_test.ts
@@ -76,9 +76,9 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = URL | string;
 
-    type EntryPointLeaf = {
+    interface EntryPointLeaf extends ThingBase {
         \\"@type\\": \\"EntryPoint\\";
-    } & ThingBase;
+    }
     export type EntryPoint = EntryPointLeaf | string;
 
     interface OrganizationBase extends ThingBase {
@@ -86,36 +86,36 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"owner\\"?: SchemaValue<Person | IdReference>;
         \\"urlTemplate\\"?: SchemaValue<URL>;
     }
-    type OrganizationLeaf = {
+    interface OrganizationLeaf extends OrganizationBase {
         \\"@type\\": \\"Organization\\";
-    } & OrganizationBase;
+    }
     export type Organization = OrganizationLeaf | string;
 
     interface PersonBase extends ThingBase {
         \\"height\\"?: SchemaValue<Quantity | IdReference>;
         \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
     }
-    type PersonLeaf = {
+    interface PersonLeaf extends PersonBase {
         \\"@type\\": \\"Person\\";
-    } & PersonBase;
+    }
     export type Person = PersonLeaf | string;
 
-    type PlaceLeaf = {
+    interface PlaceLeaf extends ThingBase {
         \\"@type\\": \\"Place\\";
-    } & ThingBase;
+    }
     export type Place = PlaceLeaf | string;
 
-    type QuantityLeaf = {
+    interface QuantityLeaf extends ThingBase {
         \\"@type\\": \\"Quantity\\";
-    } & ThingBase;
+    }
     export type Quantity = QuantityLeaf | string;
 
     interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 
     export type URL = string;

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -81,20 +81,20 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type EntryPoint = EntryPointLeaf | string;
 
-    type OrganizationBase = ThingBase & {
+    interface OrganizationBase extends ThingBase {
         \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
         \\"owner\\"?: SchemaValue<Person | IdReference>;
         \\"urlTemplate\\"?: SchemaValue<URL>;
-    };
+    }
     type OrganizationLeaf = {
         \\"@type\\": \\"Organization\\";
     } & OrganizationBase;
     export type Organization = OrganizationLeaf | string;
 
-    type PersonBase = ThingBase & {
+    interface PersonBase extends ThingBase {
         \\"height\\"?: SchemaValue<Quantity | IdReference>;
         \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
-    };
+    }
     type PersonLeaf = {
         \\"@type\\": \\"Person\\";
     } & PersonBase;
@@ -110,9 +110,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type Quantity = QuantityLeaf | string;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/stringlike_https_test.ts
+++ b/test/baselines/stringlike_https_test.ts
@@ -76,9 +76,9 @@ test(`baseine_${basename(__filename)}`, async () => {
 
     export type Text = URL | string;
 
-    type EntryPointLeaf = {
+    interface EntryPointLeaf extends ThingBase {
         \\"@type\\": \\"EntryPoint\\";
-    } & ThingBase;
+    }
     export type EntryPoint = EntryPointLeaf | string;
 
     interface OrganizationBase extends ThingBase {
@@ -86,36 +86,36 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"owner\\"?: SchemaValue<Person | IdReference>;
         \\"urlTemplate\\"?: SchemaValue<URL>;
     }
-    type OrganizationLeaf = {
+    interface OrganizationLeaf extends OrganizationBase {
         \\"@type\\": \\"Organization\\";
-    } & OrganizationBase;
+    }
     export type Organization = OrganizationLeaf | string;
 
     interface PersonBase extends ThingBase {
         \\"height\\"?: SchemaValue<Quantity | IdReference>;
         \\"locatedIn\\"?: SchemaValue<Place | IdReference>;
     }
-    type PersonLeaf = {
+    interface PersonLeaf extends PersonBase {
         \\"@type\\": \\"Person\\";
-    } & PersonBase;
+    }
     export type Person = PersonLeaf | string;
 
-    type PlaceLeaf = {
+    interface PlaceLeaf extends ThingBase {
         \\"@type\\": \\"Place\\";
-    } & ThingBase;
+    }
     export type Place = PlaceLeaf | string;
 
-    type QuantityLeaf = {
+    interface QuantityLeaf extends ThingBase {
         \\"@type\\": \\"Quantity\\";
-    } & ThingBase;
+    }
     export type Quantity = QuantityLeaf | string;
 
     interface ThingBase extends Partial<IdReference> {
         \\"name\\"?: SchemaValue<Text>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 
     export type URL = string;

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -94,7 +94,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** A type of medical procedure that involves invasive surgical techniques. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 
-    type ThingBase = Partial<IdReference>;
+    interface ThingBase extends Partial<IdReference> {
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/surgical_procedure_3_4_test.ts
+++ b/test/baselines/surgical_procedure_3_4_test.ts
@@ -63,42 +63,42 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    type EnumerationLeaf = {
+    interface EnumerationLeaf extends ThingBase {
         \\"@type\\": \\"Enumeration\\";
-    } & ThingBase;
+    }
     export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
-    type IntangibleLeaf = {
+    interface IntangibleLeaf extends ThingBase {
         \\"@type\\": \\"Intangible\\";
-    } & ThingBase;
+    }
     export type Intangible = IntangibleLeaf | Enumeration;
 
-    type MedicalEnumerationLeaf = {
+    interface MedicalEnumerationLeaf extends ThingBase {
         \\"@type\\": \\"MedicalEnumeration\\";
-    } & ThingBase;
+    }
     export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
-    type MedicalProcedureLeaf = {
+    interface MedicalProcedureLeaf extends ThingBase {
         \\"@type\\": \\"MedicalProcedure\\";
-    } & ThingBase;
+    }
     export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
-    type MedicalProcedureTypeLeaf = {
+    interface MedicalProcedureTypeLeaf extends ThingBase {
         \\"@type\\": \\"MedicalProcedureType\\";
-    } & ThingBase;
+    }
     export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"https://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
 
-    type SurgicalProcedureLeaf = {
+    interface SurgicalProcedureLeaf extends ThingBase {
         \\"@type\\": \\"SurgicalProcedure\\";
-    } & ThingBase;
+    }
     /** A type of medical procedure that involves invasive surgical techniques. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 
     interface ThingBase extends Partial<IdReference> {
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | Intangible | MedicalProcedure;
 
     "

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -94,7 +94,8 @@ test(`baseine_${basename(__filename)}`, async () => {
     /** A type of medical procedure that involves invasive surgical techniques. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 
-    type ThingBase = Partial<IdReference>;
+    interface ThingBase extends Partial<IdReference> {
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -63,42 +63,42 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    type EnumerationLeaf = {
+    interface EnumerationLeaf extends ThingBase {
         \\"@type\\": \\"Enumeration\\";
-    } & ThingBase;
+    }
     export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
-    type IntangibleLeaf = {
+    interface IntangibleLeaf extends ThingBase {
         \\"@type\\": \\"Intangible\\";
-    } & ThingBase;
+    }
     export type Intangible = IntangibleLeaf | Enumeration;
 
-    type MedicalEnumerationLeaf = {
+    interface MedicalEnumerationLeaf extends ThingBase {
         \\"@type\\": \\"MedicalEnumeration\\";
-    } & ThingBase;
+    }
     export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
-    type MedicalProcedureLeaf = {
+    interface MedicalProcedureLeaf extends ThingBase {
         \\"@type\\": \\"MedicalProcedure\\";
-    } & ThingBase;
+    }
     export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
-    type MedicalProcedureTypeLeaf = {
+    interface MedicalProcedureTypeLeaf extends ThingBase {
         \\"@type\\": \\"MedicalProcedureType\\";
-    } & ThingBase;
+    }
     export type MedicalProcedureType = \\"http://schema.org/SurgicalProcedure\\" | \\"https://schema.org/SurgicalProcedure\\" | \\"SurgicalProcedure\\" | MedicalProcedureTypeLeaf;
 
-    type SurgicalProcedureLeaf = {
+    interface SurgicalProcedureLeaf extends ThingBase {
         \\"@type\\": \\"SurgicalProcedure\\";
-    } & ThingBase;
+    }
     /** A type of medical procedure that involves invasive surgical techniques. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 
     interface ThingBase extends Partial<IdReference> {
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | Intangible | MedicalProcedure;
 
     "

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -130,13 +130,15 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type MedicalTherapy = MedicalTherapyLeaf | PalliativeProcedure;
 
-    type PalliativeProcedureBase = (ThingBase & ThingBase);
+    interface PalliativeProcedureBase extends ThingBase, ThingBase {
+    }
     type PalliativeProcedureLeaf = {
         \\"@type\\": \\"PalliativeProcedure\\";
     } & PalliativeProcedureBase;
     export type PalliativeProcedure = PalliativeProcedureLeaf;
 
-    type PhysicalExamBase = (ThingBase & ThingBase);
+    interface PhysicalExamBase extends ThingBase, ThingBase {
+    }
     type PhysicalExamLeaf = {
         \\"@type\\": \\"PhysicalExam\\";
     } & PhysicalExamBase;
@@ -153,9 +155,9 @@ test(`baseine_${basename(__filename)}`, async () => {
     } & ThingBase;
     export type TherapeuticProcedure = TherapeuticProcedureLeaf | MedicalTherapy;
 
-    type ThingBase = Partial<IdReference> & {
+    interface ThingBase extends Partial<IdReference> {
         \\"procedureType\\"?: SchemaValue<MedicalProcedureType | IdReference>;
-    };
+    }
     type ThingLeaf = {
         \\"@type\\": \\"Thing\\";
     } & ThingBase;

--- a/test/baselines/surgical_procedure_test.ts
+++ b/test/baselines/surgical_procedure_test.ts
@@ -88,79 +88,79 @@ test(`baseine_${basename(__filename)}`, async () => {
         \\"@id\\": string;
     };
 
-    type DiagnosticProcedureLeaf = {
+    interface DiagnosticProcedureLeaf extends ThingBase {
         \\"@type\\": \\"DiagnosticProcedure\\";
-    } & ThingBase;
+    }
     export type DiagnosticProcedure = DiagnosticProcedureLeaf;
 
-    type EnumerationLeaf = {
+    interface EnumerationLeaf extends ThingBase {
         \\"@type\\": \\"Enumeration\\";
-    } & ThingBase;
+    }
     export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
-    type IntangibleLeaf = {
+    interface IntangibleLeaf extends ThingBase {
         \\"@type\\": \\"Intangible\\";
-    } & ThingBase;
+    }
     export type Intangible = IntangibleLeaf | Enumeration;
 
-    type MedicalEntityLeaf = {
+    interface MedicalEntityLeaf extends ThingBase {
         \\"@type\\": \\"MedicalEntity\\";
-    } & ThingBase;
+    }
     export type MedicalEntity = MedicalEntityLeaf | MedicalProcedure;
 
-    type MedicalEnumerationLeaf = {
+    interface MedicalEnumerationLeaf extends ThingBase {
         \\"@type\\": \\"MedicalEnumeration\\";
-    } & ThingBase;
+    }
     export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType | PhysicalExam;
 
-    type MedicalProcedureLeaf = {
+    interface MedicalProcedureLeaf extends ThingBase {
         \\"@type\\": \\"MedicalProcedure\\";
-    } & ThingBase;
+    }
     /** A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques. */
     export type MedicalProcedure = MedicalProcedureLeaf | DiagnosticProcedure | PalliativeProcedure | PhysicalExam | SurgicalProcedure | TherapeuticProcedure;
 
-    type MedicalProcedureTypeLeaf = {
+    interface MedicalProcedureTypeLeaf extends ThingBase {
         \\"@type\\": \\"MedicalProcedureType\\";
-    } & ThingBase;
+    }
     /** An enumeration that describes different types of medical procedures. */
     export type MedicalProcedureType = \\"http://schema.org/NoninvasiveProcedure\\" | \\"https://schema.org/NoninvasiveProcedure\\" | \\"NoninvasiveProcedure\\" | \\"http://schema.org/PercutaneousProcedure\\" | \\"https://schema.org/PercutaneousProcedure\\" | \\"PercutaneousProcedure\\" | MedicalProcedureTypeLeaf;
 
-    type MedicalTherapyLeaf = {
+    interface MedicalTherapyLeaf extends ThingBase {
         \\"@type\\": \\"MedicalTherapy\\";
-    } & ThingBase;
+    }
     export type MedicalTherapy = MedicalTherapyLeaf | PalliativeProcedure;
 
     interface PalliativeProcedureBase extends ThingBase, ThingBase {
     }
-    type PalliativeProcedureLeaf = {
+    interface PalliativeProcedureLeaf extends PalliativeProcedureBase {
         \\"@type\\": \\"PalliativeProcedure\\";
-    } & PalliativeProcedureBase;
+    }
     export type PalliativeProcedure = PalliativeProcedureLeaf;
 
     interface PhysicalExamBase extends ThingBase, ThingBase {
     }
-    type PhysicalExamLeaf = {
+    interface PhysicalExamLeaf extends PhysicalExamBase {
         \\"@type\\": \\"PhysicalExam\\";
-    } & PhysicalExamBase;
+    }
     export type PhysicalExam = \\"http://schema.org/Head\\" | \\"https://schema.org/Head\\" | \\"Head\\" | \\"http://schema.org/Neuro\\" | \\"https://schema.org/Neuro\\" | \\"Neuro\\" | PhysicalExamLeaf;
 
-    type SurgicalProcedureLeaf = {
+    interface SurgicalProcedureLeaf extends ThingBase {
         \\"@type\\": \\"SurgicalProcedure\\";
-    } & ThingBase;
+    }
     /** A medical procedure involving an incision with instruments; performed for diagnose, or therapeutic purposes. */
     export type SurgicalProcedure = SurgicalProcedureLeaf;
 
-    type TherapeuticProcedureLeaf = {
+    interface TherapeuticProcedureLeaf extends ThingBase {
         \\"@type\\": \\"TherapeuticProcedure\\";
-    } & ThingBase;
+    }
     export type TherapeuticProcedure = TherapeuticProcedureLeaf | MedicalTherapy;
 
     interface ThingBase extends Partial<IdReference> {
         \\"procedureType\\"?: SchemaValue<MedicalProcedureType | IdReference>;
     }
-    type ThingLeaf = {
+    interface ThingLeaf extends ThingBase {
         \\"@type\\": \\"Thing\\";
-    } & ThingBase;
+    }
     export type Thing = ThingLeaf | Intangible | MedicalEntity;
 
     "

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -84,7 +84,8 @@ describe('Class', () => {
       const ctx = new Context();
       ctx.setUrlContext('https://schema.org/');
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonBase = Partial<IdReference>;
+        "interface PersonBase extends Partial<IdReference> {
+        }
         type PersonLeaf = {
             \\"@type\\": \\"Person\\";
         } & PersonBase;
@@ -112,7 +113,8 @@ describe('Class', () => {
       addParent(cls, 'https://schema.org/Thing2');
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonBase = (Thing1Base & Thing2Base);
+        "interface PersonBase extends Thing1Base, Thing2Base {
+        }
         type PersonLeaf = {
             \\"@type\\": \\"Person\\";
         } & PersonBase;

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -86,9 +86,9 @@ describe('Class', () => {
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
         "interface PersonBase extends Partial<IdReference> {
         }
-        type PersonLeaf = {
+        interface PersonLeaf extends PersonBase {
             \\"@type\\": \\"Person\\";
-        } & PersonBase;
+        }
         export type Person = PersonLeaf;"
       `);
     });
@@ -99,9 +99,9 @@ describe('Class', () => {
       addParent(cls, 'https://schema.org/Thing');
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonLeaf = {
+        "interface PersonLeaf extends ThingBase {
             \\"@type\\": \\"Person\\";
-        } & ThingBase;
+        }
         export type Person = PersonLeaf;"
       `);
     });
@@ -115,9 +115,9 @@ describe('Class', () => {
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
         "interface PersonBase extends Thing1Base, Thing2Base {
         }
-        type PersonLeaf = {
+        interface PersonLeaf extends PersonBase {
             \\"@type\\": \\"Person\\";
-        } & PersonBase;
+        }
         export type Person = PersonLeaf;"
       `);
     });
@@ -138,9 +138,9 @@ describe('Class', () => {
       ).toBe(true);
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonLeaf = {
+        "interface PersonLeaf extends ThingBase {
             \\"@type\\": \\"Person\\";
-        } & ThingBase;
+        }
         /** @deprecated Use CoolPerson instead. */
         export type Person = PersonLeaf;"
       `);
@@ -178,9 +178,9 @@ describe('Class', () => {
       ).toBe(true);
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonLeaf = {
+        "interface PersonLeaf extends ThingBase {
             \\"@type\\": \\"Person\\";
-        } & ThingBase;
+        }
         /** @deprecated Use APerson or CoolPerson instead. */
         export type Person = PersonLeaf;"
       `);
@@ -211,9 +211,9 @@ describe('Class', () => {
       ).toBe(true);
 
       expect(asString(cls, ctx)).toMatchInlineSnapshot(`
-        "type PersonLeaf = {
+        "interface PersonLeaf extends ThingBase {
             \\"@type\\": \\"Person\\";
-        } & ThingBase;
+        }
         /**
          * Fantastic
          * @deprecated Use CoolPerson instead.


### PR DESCRIPTION
I've been wanting to do this for a while. In addition to readability, there's some evidence this might help with type checking performance.

I've had trouble doing this before, not sure if restricting this to Base + Leaf solved the past issues I had (the attempts were a while ago), or if TypeScript 4 has a better handling of interface inheritance.