### PR TITLE
CLI loads local file

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -19,7 +19,7 @@ import {ArgumentParser} from 'argparse';
 export interface Options {
   /** HTTPS URL to an .nt file defining a custom ontology. */
   ontology: string;
-  file: string;
+  file: string | undefined;
   verbose: boolean;
   deprecated: boolean;
   context: string;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -19,6 +19,7 @@ import {ArgumentParser} from 'argparse';
 export interface Options {
   /** HTTPS URL to an .nt file defining a custom ontology. */
   ontology: string;
+  file: string;
   verbose: boolean;
   deprecated: boolean;
   context: string;
@@ -77,6 +78,11 @@ export function ParseFlags(args?: string[]): Options {
       "'domainIncludes', and 'rangeIncludes'.",
     metavar: 'https://url.to/schema.nt',
     dest: 'ontology',
+  });
+  parser.add_argument('--file', {
+    default: undefined,
+    help: 'file path to a .nt file, for using a local ontology file',
+    dest: 'file',
   });
 
   const deprecated = parser.add_mutually_exclusive_group({required: false});

--- a/src/cli/internal/main.ts
+++ b/src/cli/internal/main.ts
@@ -16,7 +16,7 @@
 
 import {Log, SetOptions} from '../../logging';
 import {WriteDeclarations} from '../../transform/transform';
-import {load} from '../../triples/reader';
+import {load, loadFile} from '../../triples/reader';
 import {Context} from '../../ts/context';
 
 import {ParseFlags} from '../args';
@@ -26,9 +26,16 @@ export async function main(args?: string[]) {
   SetOptions(options);
 
   const ontologyUrl = options.ontology;
-  Log(`Loading Ontology from URL: ${ontologyUrl}`);
+  const filePath = options.file;
+  let result = '';
+  if (ontologyUrl && ontologyUrl.startsWith('https://')) {
+    Log(`Loading Ontology from URL: ${ontologyUrl}`);
 
-  const result = load(ontologyUrl);
+    result = load(ontologyUrl);
+  } else if (filePath) {
+    Log(`Loading Ontology from path: ${filePath}`);
+    result = loadFile(filePath);
+  }
   const context = Context.Parse(options.context);
   await WriteDeclarations(result, options.deprecated, context, write);
 }

--- a/src/cli/internal/main.ts
+++ b/src/cli/internal/main.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {Observable} from 'rxjs';
+import {Triple} from '../..';
 import {Log, SetOptions} from '../../logging';
 import {WriteDeclarations} from '../../transform/transform';
 import {load, loadFile} from '../../triples/reader';
@@ -27,14 +29,15 @@ export async function main(args?: string[]) {
 
   const ontologyUrl = options.ontology;
   const filePath = options.file;
-  let result;
-  if (ontologyUrl && ontologyUrl.startsWith('https://')) {
+  let result: Observable<Triple>;
+
+  if (filePath) {
+    Log(`Loading Ontology from path: ${filePath}`);
+    result = loadFile(filePath);
+  } else {
     Log(`Loading Ontology from URL: ${ontologyUrl}`);
 
     result = load(ontologyUrl);
-  } else if (filePath) {
-    Log(`Loading Ontology from path: ${filePath}`);
-    result = loadFile(filePath);
   }
   if (!result) {
     Log(`Ontology could not be read`);

--- a/src/cli/internal/main.ts
+++ b/src/cli/internal/main.ts
@@ -27,7 +27,7 @@ export async function main(args?: string[]) {
 
   const ontologyUrl = options.ontology;
   const filePath = options.file;
-  let result = '';
+  let result;
   if (ontologyUrl && ontologyUrl.startsWith('https://')) {
     Log(`Loading Ontology from URL: ${ontologyUrl}`);
 
@@ -35,6 +35,10 @@ export async function main(args?: string[]) {
   } else if (filePath) {
     Log(`Loading Ontology from path: ${filePath}`);
     result = loadFile(filePath);
+  }
+  if (!result) {
+    Log(`Ontology could not be read`);
+    return;
   }
   const context = Context.Parse(options.context);
   await WriteDeclarations(result, options.deprecated, context, write);

--- a/src/cli/internal/main.ts
+++ b/src/cli/internal/main.ts
@@ -36,12 +36,7 @@ export async function main(args?: string[]) {
     result = loadFile(filePath);
   } else {
     Log(`Loading Ontology from URL: ${ontologyUrl}`);
-
     result = load(ontologyUrl);
-  }
-  if (!result) {
-    Log(`Ontology could not be read`);
-    return;
   }
   const context = Context.Parse(options.context);
   await WriteDeclarations(result, options.deprecated, context, write);

--- a/src/triples/reader.ts
+++ b/src/triples/reader.ts
@@ -95,10 +95,22 @@ function handleFile(
     crlfDelay: Infinity,
   });
 
+  const data: string[] = [];
+
   rl.on('line', (line: string) => {
-    subscriber.next(line);
+    data.push(line);
   });
+
   rl.on('close', () => {
+    try {
+      const triples = toTripleStrings(data);
+      for (const triple of process(triples)) {
+        subscriber.next(triple);
+      }
+    } catch (error) {
+      Log(`Caught Error on end: ${error}`);
+      subscriber.error(error);
+    }
     subscriber.complete();
   });
 }

--- a/src/triples/reader.ts
+++ b/src/triples/reader.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import https from 'https';
+import fs from 'fs';
+import readline from 'readline';
 import {Observable, Subscriber, TeardownLogic} from 'rxjs';
 
 import {Log} from '../logging';
@@ -72,6 +74,32 @@ export function toTripleStrings(data: string[]) {
 export function load(url: string): Observable<Triple> {
   return new Observable<Triple>(subscriber => {
     handleUrl(url, subscriber);
+  });
+}
+
+/**
+ * does the same as load(), but for a local file
+ */
+export function loadFile(path: string): Observable<Triple> {
+  return new Observable<Triple>(subscriber => {
+    handleFile(path, subscriber);
+  });
+}
+
+function handleFile(
+  path: string,
+  subscriber: Subscriber<Triple>
+): TeardownLogic {
+  const rl = readline.createInterface({
+    input: fs.createReadStream(path),
+    crlfDelay: Infinity,
+  });
+
+  rl.on('line', (line: string) => {
+    subscriber.next(line);
+  });
+  rl.on('close', () => {
+    subscriber.complete();
   });
 }
 

--- a/test/cli/args_logmessages_test.ts
+++ b/test/cli/args_logmessages_test.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {Readable} from 'stream';
+import fs from 'fs';
+import {main} from '../../src/cli/internal/main';
+import * as Logging from '../../src/logging';
+import * as Transform from '../../src/transform/transform';
+
+describe('main Args logs', () => {
+  let readStreamCreatorFn: jest.SpyInstance;
+  beforeEach(() => {
+    const mockFileLine = `<http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .\n`;
+    const mockedStream = Readable.from([mockFileLine]);
+    readStreamCreatorFn = jest
+      .spyOn(fs, 'createReadStream')
+      //@ts-ignore
+      .mockImplementation(path => mockedStream);
+  });
+  it(`the path it is loading from`, async () => {
+    let logs = [''];
+    // log messages get caught for checking assert:
+    jest
+      .spyOn(Logging, 'Log')
+      .mockImplementation((msg: string) => void logs.push(msg));
+    // but doesn't write the output .ts-file:
+    jest
+      .spyOn(Transform, 'WriteDeclarations')
+      .mockImplementation(async (...args) => {});
+    await main(['--file', `ontology-file.nt`, `--verbose`]);
+    expect(logs.join('')).toMatchInlineSnapshot(
+      `"Loading Ontology from path: ontology-file.nt"`
+    );
+  });
+});

--- a/test/cli/args_logmessages_test.ts
+++ b/test/cli/args_logmessages_test.ts
@@ -32,7 +32,7 @@ describe('main Args logs', () => {
       .mockImplementation(path => mockedStream);
   });
   it(`the path it is loading from`, async () => {
-    let logs = [''];
+    const logs = [''];
     // log messages get caught for checking assert:
     jest
       .spyOn(Logging, 'Log')

--- a/test/cli/args_test.ts
+++ b/test/cli/args_test.ts
@@ -24,6 +24,7 @@ describe('ParseFlags', () => {
     expect(options.context).toBe('https://schema.org');
     expect(options.deprecated).toBe(true);
     expect(options.verbose).toBe(false);
+    expect(options.file).toBeUndefined();
 
     expect(options.ontology).toBe(
       'https://schema.org/version/latest/schemaorg-current-https.nt'
@@ -35,6 +36,13 @@ describe('ParseFlags', () => {
     expect(options).not.toBeUndefined();
 
     expect(options.ontology).toBe('https://google.com/foo');
+  });
+
+  it('custom file', () => {
+    const options = ParseFlags(['--file', './ontology.nt'])!;
+    expect(options).not.toBeUndefined();
+
+    expect(options.file).toBe('./ontology.nt');
   });
 
   describe('deprecated fields', () => {

--- a/test/triples/reader_test.ts
+++ b/test/triples/reader_test.ts
@@ -17,9 +17,10 @@
 import {ClientRequest, IncomingMessage} from 'http';
 import https from 'https';
 import {toArray} from 'rxjs/operators';
-import {PassThrough, Writable} from 'stream';
+import {PassThrough, Readable, Writable} from 'stream';
 
-import {load} from '../../src/triples/reader';
+import fs from 'fs';
+import {load, loadFile} from '../../src/triples/reader';
 import {Triple} from '../../src/triples/triple';
 import {SchemaString, UrlNode} from '../../src/triples/types';
 import {flush} from '../helpers/async';
@@ -432,6 +433,29 @@ describe('load', () => {
             Object: SchemaString.Parse('"science"')!,
           },
         ]);
+      });
+    });
+    describe('local file', () => {
+      let readStreamCreatorFn: jest.SpyInstance;
+      beforeEach(() => {
+        const mockFileLine = `<https://schema.org/Person> <https://schema.org/knowsAbout> <https://schema.org/Event> .\n`;
+        const mockedStream = Readable.from([mockFileLine]);
+        readStreamCreatorFn = jest
+          .spyOn(fs, 'createReadStream')
+          //@ts-ignore
+          .mockImplementation(path => mockedStream);
+      });
+      it('loads a file from the correct path', async () => {
+        const mockFilePath = './ontology.nt';
+
+        const fileTriples = loadFile(mockFilePath).toPromise();
+
+        expect(readStreamCreatorFn).toBeCalledWith(mockFilePath);
+        await expect(fileTriples).resolves.toEqual({
+          Subject: UrlNode.Parse('https://schema.org/Person'),
+          Predicate: UrlNode.Parse('https://schema.org/knowsAbout'),
+          Object: UrlNode.Parse('https://schema.org/Event')!,
+        });
       });
     });
   });

--- a/test/triples/reader_test.ts
+++ b/test/triples/reader_test.ts
@@ -445,6 +445,15 @@ describe('load', () => {
           //@ts-ignore
           .mockImplementation(path => mockedStream);
       });
+      it('fails loading a file (containing .nt syntax errors)', async () => {
+        const failingMockPath = './bad-ontology.nt';
+        const failingMockLine = `<https://schema.org/knowsAbout> <https://sc`;
+        const failingMockedStream = Readable.from([failingMockLine]);
+        readStreamCreatorFn.mockImplementation(path => failingMockedStream);
+
+        const fileTriples = loadFile(failingMockPath).toPromise();
+        await expect(fileTriples).rejects.toThrow('Unexpected');
+      });
       it('loads a file from the correct path', async () => {
         const mockFilePath = './ontology.nt';
 


### PR DESCRIPTION
Fixes #145 

the --ontology argument will have priority, unless it explicitly isn't prefixed with "https://", then there's an additional --file argument now. So you have to deliberatly switch it off, like so: `schema-dts-gen --ontology=doNotUse --file=./somefolder/ontology.nt`