### PR TITLE
Support for Generic `Role`

### DIFF
--- a/src/transform/toClass.ts
+++ b/src/transform/toClass.ts
@@ -17,8 +17,14 @@
 import {Log} from '../logging';
 import {ObjectPredicate, Topic, TypedTopic} from '../triples/triple';
 import {UrlNode} from '../triples/types';
-import {IsNamedClass, IsWellKnown, IsDataType} from '../triples/wellKnown';
-import {AliasBuiltin, Class, ClassMap, DataTypeUnion} from '../ts/class';
+import {IsNamedClass, IsDataType, ClassIsDataType} from '../triples/wellKnown';
+import {
+  AliasBuiltin,
+  Class,
+  ClassMap,
+  DataTypeUnion,
+  RoleBuiltin,
+} from '../ts/class';
 import {assert} from '../util/assert';
 
 function toClass(cls: Class, topic: Topic, map: ClassMap): Class {
@@ -51,6 +57,11 @@ const wellKnownTypes = [
   new AliasBuiltin('http://schema.org/Date', AliasBuiltin.Alias('string')),
   new AliasBuiltin('http://schema.org/DateTime', AliasBuiltin.Alias('string')),
   new AliasBuiltin('http://schema.org/Boolean', AliasBuiltin.Alias('boolean')),
+  new RoleBuiltin(UrlNode.Parse('http://schema.org/Role')),
+  new RoleBuiltin(UrlNode.Parse('http://schema.org/OrganizationRole')),
+  new RoleBuiltin(UrlNode.Parse('http://schema.org/EmployeeRole')),
+  new RoleBuiltin(UrlNode.Parse('http://schema.org/LinkRole')),
+  new RoleBuiltin(UrlNode.Parse('http://schema.org/PerformanceRole')),
 ];
 
 // Should we allow 'string' to be a valid type for all values of this type?
@@ -78,12 +89,14 @@ function ForwardDeclareClasses(topics: readonly TypedTopic[]): ClassMap {
     } else if (!IsNamedClass(topic)) continue;
 
     const wk = wellKnownTypes.find(wk => wk.subject.equivTo(topic.Subject));
-    if (IsWellKnown(topic)) {
+    if (ClassIsDataType(topic)) {
       assert(
         wk,
         `${topic.Subject.toString()} must have corresponding well-known type.`
       );
       dataType.wk.push(wk);
+
+      wk['_isDataType'] = true;
     }
 
     const cls = wk || new Class(topic.Subject);

--- a/src/transform/toClass.ts
+++ b/src/transform/toClass.ts
@@ -75,19 +75,18 @@ function ForwardDeclareClasses(topics: readonly TypedTopic[]): ClassMap {
     if (IsDataType(topic.Subject)) {
       classes.set(topic.Subject.toString(), dataType);
       continue;
-    } else if (IsWellKnown(topic)) {
-      const wk = wellKnownTypes.find(wk => wk.subject.equivTo(topic.Subject));
-      if (!wk) {
-        throw new Error(
-          `Non-Object type ${topic.Subject.toString()} has no corresponding well-known type.`
-        );
-      }
-      classes.set(topic.Subject.toString(), wk);
-      dataType.wk.push(wk);
-      continue;
     } else if (!IsNamedClass(topic)) continue;
 
-    const cls = new Class(topic.Subject);
+    const wk = wellKnownTypes.find(wk => wk.subject.equivTo(topic.Subject));
+    if (IsWellKnown(topic)) {
+      assert(
+        wk,
+        `${topic.Subject.toString()} must have corresponding well-known type.`
+      );
+      dataType.wk.push(wk);
+    }
+
+    const cls = wk || new Class(topic.Subject);
     const allowString = wellKnownStrings.some(wks =>
       wks.equivTo(topic.Subject)
     );

--- a/src/triples/wellKnown.ts
+++ b/src/triples/wellKnown.ts
@@ -84,7 +84,7 @@ export function IsDataType(t: TTypeName): boolean {
 }
 
 /** Returns true iff a Topic represents a DataType. */
-export function IsWellKnown(topic: TypedTopic): boolean {
+export function ClassIsDataType(topic: TypedTopic): boolean {
   if (topic.types.some(IsDataType)) return true;
   return false;
 }

--- a/src/ts/util/union.ts
+++ b/src/ts/util/union.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,19 @@
  * limitations under the License.
  */
 
-export function arrayOf<T>(
-  ...args: Array<T | undefined | null | 0 | '' | false>
-): T[] {
-  return args.filter((elem): elem is T => !!elem);
+import {factory, SyntaxKind, TypeNode} from 'typescript';
+
+export function typeUnion(
+  ...args: Array<TypeNode | undefined | null | false>
+): TypeNode {
+  const types = args.filter((elem): elem is TypeNode => !!elem);
+
+  switch (types.length) {
+    case 0:
+      return factory.createKeywordTypeNode(SyntaxKind.NeverKeyword);
+    case 1:
+      return types[0];
+    default:
+      return factory.createUnionTypeNode(types);
+  }
 }

--- a/test/baselines/role_inheritance_test.ts
+++ b/test/baselines/role_inheritance_test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Baseline tests are a set of tests (in tests/baseline/) that
+ * correspond to full comparisons of a generate .ts output based on a set of
+ * Triples representing an entire ontology.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver';
+
+test(`baseline_${basename(__filename)}`, async () => {
+  const {actual} = await inlineCli(
+    `
+<https://schema.org/name> <https://schema.org/rangeIncludes> <https://schema.org/Text> .
+<https://schema.org/name> <https://schema.org/domainIncludes> <https://schema.org/Thing> .
+<https://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<https://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/DataType> .
+<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/Role> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.\\n\\nSee also [blog post](http://blog.schema.org/2014/06/introducing-role.html)." .
+<https://schema.org/Role> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://schema.org/Intangible> .
+<https://schema.org/Role> <http://www.w3.org/2000/01/rdf-schema#label> "Role" .
+<https://schema.org/Role> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/Intangible> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/Intangible> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://schema.org/Thing> .
+<https://schema.org/startDate> <https://schema.org/domainIncludes> <https://schema.org/Role> .
+<https://schema.org/startDate> <https://schema.org/rangeIncludes> <https://schema.org/DateTime> .
+<https://schema.org/startDate> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<https://schema.org/DateTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/DateTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/OrganizationRole> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://schema.org/Role> .
+<https://schema.org/OrganizationRole> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+
+      `,
+    ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
+  );
+
+  expect(actual).toMatchInlineSnapshot(`
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    \\"@context\\": \\"https://schema.org\\";
+};
+export interface Graph {
+    \\"@context\\": \\"https://schema.org\\";
+    \\"@graph\\": readonly Thing[];
+}
+type SchemaValue<T, TProperty extends string> = T | Role<T, TProperty> | readonly (T | Role<T, TProperty>)[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    \\"@id\\": string;
+};
+
+interface DateTimeBase extends Partial<IdReference> {
+}
+interface DateTimeLeaf extends DateTimeBase {
+    \\"@type\\": \\"DateTime\\";
+}
+export type DateTime = DateTimeLeaf | string;
+
+type OrganizationRoleLeaf<TContent, TProperty extends string> = RoleBase & {
+    \\"@type\\": \\"OrganizationRole\\";
+} & {
+    [key in TProperty]: TContent;
+};
+export type OrganizationRole<TContent = never, TProperty extends string = never> = OrganizationRoleLeaf<TContent, TProperty>;
+
+interface RoleBase extends ThingBase {
+    \\"startDate\\"?: SchemaValue<DateTime | IdReference, \\"startDate\\">;
+}
+type RoleLeaf<TContent, TProperty extends string> = RoleBase & {
+    \\"@type\\": \\"Role\\";
+} & {
+    [key in TProperty]: TContent;
+};
+/**
+ * Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.
+ *
+ * See also {@link http://blog.schema.org/2014/06/introducing-role.html blog post}.
+ */
+export type Role<TContent = never, TProperty extends string = never> = RoleLeaf<TContent, TProperty> | OrganizationRole<TContent, TProperty>;
+
+export type Text = string;
+
+interface IntangibleLeaf extends ThingBase {
+    \\"@type\\": \\"Intangible\\";
+}
+export type Intangible = IntangibleLeaf | Role;
+
+interface ThingBase extends Partial<IdReference> {
+    \\"name\\"?: SchemaValue<Text, \\"name\\">;
+}
+interface ThingLeaf extends ThingBase {
+    \\"@type\\": \\"Thing\\";
+}
+export type Thing = ThingLeaf | Intangible;
+
+"
+`);
+});

--- a/test/baselines/role_simple_test.ts
+++ b/test/baselines/role_simple_test.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Baseline tests are a set of tests (in tests/baseline/) that
+ * correspond to full comparisons of a generate .ts output based on a set of
+ * Triples representing an entire ontology.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver';
+
+test(`baseline_${basename(__filename)}`, async () => {
+  const {actual} = await inlineCli(
+    `
+<https://schema.org/name> <https://schema.org/rangeIncludes> <https://schema.org/Text> .
+<https://schema.org/name> <https://schema.org/domainIncludes> <https://schema.org/Thing> .
+<https://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<https://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/DataType> .
+<https://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/Role> <http://www.w3.org/2000/01/rdf-schema#comment> "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.\\n\\nSee also [blog post](http://blog.schema.org/2014/06/introducing-role.html)." .
+<https://schema.org/Role> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://schema.org/Intangible> .
+<https://schema.org/Role> <http://www.w3.org/2000/01/rdf-schema#label> "Role" .
+<https://schema.org/Role> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/Intangible> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/Intangible> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://schema.org/Thing> .
+<https://schema.org/startDate> <https://schema.org/domainIncludes> <https://schema.org/Role> .
+<https://schema.org/startDate> <https://schema.org/rangeIncludes> <https://schema.org/DateTime> .
+<https://schema.org/startDate> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+<https://schema.org/DateTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<https://schema.org/DateTime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+      `,
+    ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
+  );
+
+  expect(actual).toMatchInlineSnapshot(`
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    \\"@context\\": \\"https://schema.org\\";
+};
+export interface Graph {
+    \\"@context\\": \\"https://schema.org\\";
+    \\"@graph\\": readonly Thing[];
+}
+type SchemaValue<T, TProperty extends string> = T | Role<T, TProperty> | readonly (T | Role<T, TProperty>)[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    \\"@id\\": string;
+};
+
+interface DateTimeBase extends Partial<IdReference> {
+}
+interface DateTimeLeaf extends DateTimeBase {
+    \\"@type\\": \\"DateTime\\";
+}
+export type DateTime = DateTimeLeaf | string;
+
+interface RoleBase extends ThingBase {
+    \\"startDate\\"?: SchemaValue<DateTime | IdReference, \\"startDate\\">;
+}
+type RoleLeaf<TContent, TProperty extends string> = RoleBase & {
+    \\"@type\\": \\"Role\\";
+} & {
+    [key in TProperty]: TContent;
+};
+/**
+ * Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.
+ *
+ * See also {@link http://blog.schema.org/2014/06/introducing-role.html blog post}.
+ */
+export type Role<TContent = never, TProperty extends string = never> = RoleLeaf<TContent, TProperty>;
+
+export type Text = string;
+
+interface IntangibleLeaf extends ThingBase {
+    \\"@type\\": \\"Intangible\\";
+}
+export type Intangible = IntangibleLeaf | Role;
+
+interface ThingBase extends Partial<IdReference> {
+    \\"name\\"?: SchemaValue<Text, \\"name\\">;
+}
+interface ThingLeaf extends ThingBase {
+    \\"@type\\": \\"Thing\\";
+}
+export type Thing = ThingLeaf | Intangible;
+
+"
+`);
+});

--- a/test/baselines/unknown_wellknown_test.ts
+++ b/test/baselines/unknown_wellknown_test.ts
@@ -36,5 +36,5 @@ test(`baseline_${basename(__filename)}`, async () => {
       `,
       ['--ontology', `https://fake.com/${basename(__filename)}.nt`]
     )
-  ).rejects.toThrow('has no corresponding well-known type');
+  ).rejects.toThrow('must have corresponding well-known type.');
 });

--- a/test/ts/class_test.ts
+++ b/test/ts/class_test.ts
@@ -237,7 +237,9 @@ describe('Class', () => {
         )
       ).toBe(true);
 
-      expect(() => cls.toNode(ctx, true)).toThrowError('unknown node type');
+      expect(() =>
+        cls.toNode(ctx, {skipDeprecatedProperties: true, hasRole: false})
+      ).toThrowError('unknown node type');
     });
   });
 });
@@ -496,7 +498,10 @@ function asString(
   const printer = createPrinter({newLine: NewLineKind.LineFeed});
 
   return cls
-    .toNode(context, !!skipDeprecated)
+    .toNode(context, {
+      skipDeprecatedProperties: !!skipDeprecated,
+      hasRole: false,
+    })
     .map(node => printer.printNode(EmitHint.Unspecified, node, source))
     .join('\n');
 }


### PR DESCRIPTION
Supports Role fully as described in http://blog.schema.org/2014/06/introducing-role.html

Every Property can now be a Role.

This is a pretty risky change, I published [`schema-dts@0.11.0-beta.1`](https://www.npmjs.com/package/schema-dts/v/0.11.0-beta.1) as an example.

Examples of diffs:

```diff
-declare type SchemaValue<T> = T | readonly T[];
+declare type SchemaValue<T, TProperty extends string> = T | Role<T, TProperty> | readonly (T | Role<T, TProperty>)[];
```

```diff
-interface RoleLeaf extends RoleBase {
-    "@type": "Role";
-}
-export declare type Role = RoleLeaf | LinkRole | OrganizationRole | PerformanceRole;
+declare type RoleLeaf<TContent, TProperty extends string> = RoleBase & {
+    "@type": "Role";
+} & {
+    [key in TProperty]: TContent;
+};
+export declare type Role<TContent = never, TProperty extends string = never> = RoleLeaf<TContent, TProperty> | LinkRole<TContent, TProperty> | OrganizationRole<TContent, TProperty> | PerformanceRole<TContent, TProperty>;
```

```diff
 interface PersonBase extends ThingBase {
-    "worksFor"?: SchemaValue<Organization | IdReference>;
+    "worksFor"?: SchemaValue<Organization | IdReference, "worksFor">;
 }
```

For schema-dts-gen, this change only becomes visible once a `Role` property is present. I might end up regretting this.

Fixes #143 