### PR TITLE
Initial support for OWL-awareness

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules/
-dist
 coverage
 jest.config.js
+schema-dts/lib/
+schema-dts/dist/

--- a/packages/schema-dts-gen/src/triples/reader.ts
+++ b/packages/schema-dts-gen/src/triples/reader.ts
@@ -53,7 +53,7 @@ function object(content: string) {
 }
 
 const totalRegex =
-  /\s*<([^<>]+)>\s*<([^<>]+)>\s*((?:<[^<>"]+>)|(?:"(?:[^"]|(?:\\"))+(?:[^\"]|\\")"(?:@[a-zA-Z]+)?))\s*\./;
+  /\s*<([^<>]+)>\s*<([^<>]+)>\s*((?:<[^<>"]+>)|(?:"(?:[^"]|(?:\\"))*(?:[^\"]|\\")"(?:@[a-zA-Z]+)?))\s*\./;
 export function toTripleStrings(data: string[]) {
   const linearTriples = data
     .join('')
@@ -215,7 +215,9 @@ export function* process(triples: string[][]): Iterable<Triple> {
     } catch (parseError) {
       const e = parseError as Error;
       throw new Error(
-        `ParseError: ${e.name}: ${e.message} while parsing line ${match}.\nOriginal Stack:\n${e.stack}\nRethrown from:`
+        `ParseError: ${e.name}: ${e.message} while parsing line ${match
+          .map(t => `\{${t}\}`)
+          .join(', ')}.\nOriginal Stack:\n${e.stack}\nRethrown from:`
       );
     }
   }

--- a/packages/schema-dts-gen/src/triples/triple.ts
+++ b/packages/schema-dts-gen/src/triples/triple.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Rdfs, SchemaString, UrlNode} from './types.js';
+import {NamedUrlNode, Rdfs, SchemaString, UrlNode} from './types.js';
 
 /** Represents a parsed Subject-Predicate-Object statement. */
 export interface Triple {
@@ -41,7 +41,7 @@ export interface ObjectPredicate {
  * A Node that can correspond to a "concept" in the ontology (class, property,
  * etc.).
  */
-export type TTypeName = UrlNode;
+export type TTypeName = NamedUrlNode;
 
 /** A set of statements applying to the same Subject. */
 export interface Topic {

--- a/packages/schema-dts-gen/src/ts/context.ts
+++ b/packages/schema-dts-gen/src/ts/context.ts
@@ -57,7 +57,15 @@ export class Context {
   getScopedName(node: TSubject): string {
     for (const [name, url] of this.context) {
       if (node.matchesContext(url)) {
-        return name === '' ? node.name : `${name}:${node.name}`;
+        // Valid possibilities:
+        // - "schema:Foo"  when name == schema && node.name == Foo.
+        // - "schema:"     when name == schema && node.name is undefined.
+        // - "Foo"         when name is empty and node.name is Foo.
+        //
+        // Don't allow "" when name is empty and  node.name is undefined.
+        return name === ''
+          ? node.name ?? node.toString()
+          : `${name}:${node.name || ''}`;
       }
     }
     return node.toString();

--- a/packages/schema-dts-gen/src/ts/enum.ts
+++ b/packages/schema-dts-gen/src/ts/enum.ts
@@ -18,11 +18,12 @@ import type {TypeNode} from 'typescript';
 const {factory} = ts;
 
 import {Log} from '../logging/index.js';
-import {ObjectPredicate, TSubject, TTypeName} from '../triples/triple.js';
+import {ObjectPredicate, TSubject} from '../triples/triple.js';
 import {GetComment, IsClassType, IsDataType} from '../triples/wellKnown.js';
 
 import {ClassMap} from './class.js';
 import {Context} from './context.js';
+import {UrlNode} from '../index.js';
 
 /**
  * Corresponds to a value that belongs to an Enumeration.
@@ -33,7 +34,7 @@ export class EnumValue {
   private comment?: string;
   constructor(
     readonly value: TSubject,
-    types: readonly TTypeName[],
+    types: readonly UrlNode[],
     map: ClassMap
   ) {
     for (const type of types) {

--- a/packages/schema-dts-gen/src/util/assert.ts
+++ b/packages/schema-dts-gen/src/util/assert.ts
@@ -22,3 +22,20 @@ export function assert<T>(
 ): asserts item is T {
   ok(item, message);
 }
+
+export function assertIs<T, U extends T>(
+  item: T,
+  assertion: (i: T) => i is U,
+  message?: string
+): asserts item is U {
+  ok(assertion(item), message);
+}
+
+export function asserted<T, U extends T>(
+  item: T,
+  assertion: (i: T) => i is U,
+  message?: string
+): U {
+  assertIs(item, assertion, message);
+  return item;
+}

--- a/packages/schema-dts-gen/test/baselines/invalid_schemas_test.ts
+++ b/packages/schema-dts-gen/test/baselines/invalid_schemas_test.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Baseline tests are a set of tests (in tests/baseline/) that
+ * correspond to full comparisons of a generate .ts output based on a set of
+ * Triples representing an entire ontology.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver.js';
+
+test(`invalidSyntax_${basename(import.meta.url)}`, async () => {
+  const run = inlineCli(
+    `
+ <"INVALID> <http://www.w3.org/1999/02/22-rdf-s> "X" .
+       `,
+    ['--ontology', `https://fake.com/${basename(import.meta.url)}.nt`]
+  );
+
+  await expect(run).rejects.toThrowError('ParseError');
+});
+
+test(`unnamedURLClass_${basename(import.meta.url)}`, async () => {
+  const run = inlineCli(
+    `
+ <http://schema.org/> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+       `,
+    ['--ontology', `https://fake.com/${basename(import.meta.url)}.nt`]
+  );
+
+  await expect(run).rejects.toThrowError('Unexpected unnamed URL');
+});
+
+test(`notMarkedAsClass_cycle_${basename(import.meta.url)}`, async () => {
+  const run = inlineCli(
+    `
+ <http://schema.org/name> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+ <http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+ <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+ <http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+ <http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Person> .
+ <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+ <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Thing> .
+ <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+ <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+ <http://schema.org/Text> <http://www.w3.org/2000/01/rdf-schema#comment> "Data type: Text." .
+       `,
+    ['--ontology', `https://fake.com/${basename(import.meta.url)}.nt`]
+  );
+
+  await expect(run).rejects.toThrowError(
+    'Thing is not marked as an rdfs:Class'
+  );
+});

--- a/packages/schema-dts-gen/test/baselines/owl_mixed_basic_test.ts
+++ b/packages/schema-dts-gen/test/baselines/owl_mixed_basic_test.ts
@@ -1,0 +1,203 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Baseline tests are a set of tests (in tests/baseline/) that
+ * correspond to full comparisons of a generate .ts output based on a set of
+ * Triples representing an entire ontology.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver.js';
+
+test(`baseline_mixedOWL1_${basename(import.meta.url)}`, async () => {
+  const {actual} = await inlineCli(
+    `
+   <http://schema.org/name> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+   <http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+   <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+   <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#FunctionalProperty> .
+   <http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+   <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+   <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+   <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+   <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Thing> .
+   <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+   <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+   <http://schema.org/Text> <http://www.w3.org/2000/01/rdf-schema#comment> "Data type: Text." .
+         `,
+    ['--ontology', `https://fake.com/${basename(import.meta.url)}.nt`]
+  );
+
+  expect(actual).toMatchInlineSnapshot(`
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    \\"@context\\": \\"https://schema.org\\";
+};
+export interface Graph {
+    \\"@context\\": \\"https://schema.org\\";
+    \\"@graph\\": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    \\"@id\\": string;
+};
+
+/** Data type: Text. */
+export type Text = string;
+
+interface PersonLeaf extends ThingBase {
+    \\"@type\\": \\"Person\\";
+}
+/** ABC */
+export type Person = PersonLeaf | string;
+
+interface ThingBase extends Partial<IdReference> {
+    \\"name\\"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    \\"@type\\": \\"Thing\\";
+}
+/** ABC */
+export type Thing = ThingLeaf | Person;
+
+"
+`);
+});
+
+test(`baseline_mixedOWL2_${basename(import.meta.url)}`, async () => {
+  const {actual} = await inlineCli(
+    `
+   <http://schema.org/name> <http://www.w3.org/2000/01/rdf-schema#range> <http://schema.org/Text> .
+   <http://schema.org/name> <http://www.w3.org/2000/01/rdf-schema#domain> <http://schema.org/Thing> .
+   <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+   <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> .
+   <http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+   <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+   <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+   <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+   <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Thing> .
+   <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+   <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+   <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+   <http://schema.org/Text> <http://www.w3.org/2000/01/rdf-schema#comment> "Data type: Text." .
+         `,
+    ['--ontology', `https://fake.com/${basename(import.meta.url)}.nt`]
+  );
+
+  expect(actual).toMatchInlineSnapshot(`
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    \\"@context\\": \\"https://schema.org\\";
+};
+export interface Graph {
+    \\"@context\\": \\"https://schema.org\\";
+    \\"@graph\\": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    \\"@id\\": string;
+};
+
+/** Data type: Text. */
+export type Text = string;
+
+interface PersonLeaf extends ThingBase {
+    \\"@type\\": \\"Person\\";
+}
+/** ABC */
+export type Person = PersonLeaf | string;
+
+interface ThingBase extends Partial<IdReference> {
+    \\"name\\"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    \\"@type\\": \\"Thing\\";
+}
+/** ABC */
+export type Thing = ThingLeaf | Person;
+
+"
+`);
+});
+
+test(`baseline_OWLenum_${basename(import.meta.url)}`, async () => {
+  const {actual} = await inlineCli(
+    `
+   <http://schema.org/name> <http://www.w3.org/2000/01/rdf-schema#range> <http://schema.org/Text> .
+   <http://schema.org/name> <http://www.w3.org/2000/01/rdf-schema#domain> <http://schema.org/Thing> .
+   <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+   <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> .
+   <http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+   <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+   <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+   <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+   <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Thing> .
+   <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+   <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+   <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+   <http://schema.org/Text> <http://www.w3.org/2000/01/rdf-schema#comment> "Data type: Text." .
+   <http://www.w3.org/2002/07/owl#MyEnum> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+   <http://www.w3.org/2002/07/owl#MyEnum> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+   <http://www.w3.org/2002/07/owl#EnumValueA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#MyEnum> .
+   <http://www.w3.org/2002/07/owl#EnumValueB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#MyEnum> .
+         `,
+    ['--ontology', `https://fake.com/${basename(import.meta.url)}.nt`]
+  );
+
+  expect(actual).toMatchInlineSnapshot(`
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    \\"@context\\": \\"https://schema.org\\";
+};
+export interface Graph {
+    \\"@context\\": \\"https://schema.org\\";
+    \\"@graph\\": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    \\"@id\\": string;
+};
+
+/** Data type: Text. */
+export type Text = string;
+
+interface MyEnumBase extends Partial<IdReference> {
+}
+interface MyEnumLeaf extends MyEnumBase {
+    \\"@type\\": \\"http://www.w3.org/2002/07/owl#MyEnum\\";
+}
+export type MyEnum = \\"http://www.w3.org/2002/07/owl#EnumValueA\\" | \\"https://www.w3.org/2002/07/owl#EnumValueA\\" | \\"http://www.w3.org/2002/07/owl#EnumValueB\\" | \\"https://www.w3.org/2002/07/owl#EnumValueB\\" | MyEnumLeaf;
+
+interface PersonLeaf extends ThingBase {
+    \\"@type\\": \\"Person\\";
+}
+/** ABC */
+export type Person = PersonLeaf | string;
+
+interface ThingBase extends Partial<IdReference> {
+    \\"name\\"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    \\"@type\\": \\"Thing\\";
+}
+/** ABC */
+export type Thing = ThingLeaf | Person;
+
+"
+`);
+});

--- a/packages/schema-dts-gen/test/baselines/transitive_class_test.ts
+++ b/packages/schema-dts-gen/test/baselines/transitive_class_test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Baseline tests are a set of tests (in tests/baseline/) that
+ * correspond to full comparisons of a generate .ts output based on a set of
+ * Triples representing an entire ontology.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver.js';
+
+test(`baseline_${basename(import.meta.url)}`, async () => {
+  const {actual} = await inlineCli(
+    `
+  <http://schema.org/name> <http://schema.org/rangeIncludes> <http://schema.org/Text> .
+  <http://schema.org/name> <http://schema.org/domainIncludes> <http://schema.org/Thing> .
+  <http://schema.org/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+  <http://schema.org/Thing> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+  <http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+  <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#comment> "ABC" .
+  <http://schema.org/Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Thing> .
+  <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+  <http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+  <http://schema.org/Text> <http://www.w3.org/2000/01/rdf-schema#comment> "Data type: Text." .
+        `,
+    ['--ontology', `https://fake.com/${basename(import.meta.url)}.nt`]
+  );
+
+  expect(actual).toMatchInlineSnapshot(`
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    \\"@context\\": \\"https://schema.org\\";
+};
+export interface Graph {
+    \\"@context\\": \\"https://schema.org\\";
+    \\"@graph\\": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    \\"@id\\": string;
+};
+
+/** Data type: Text. */
+export type Text = string;
+
+interface PersonLeaf extends ThingBase {
+    \\"@type\\": \\"Person\\";
+}
+/** ABC */
+export type Person = PersonLeaf | string;
+
+interface ThingBase extends Partial<IdReference> {
+    \\"name\\"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    \\"@type\\": \\"Thing\\";
+}
+/** ABC */
+export type Thing = ThingLeaf | Person;
+
+"
+`);
+});

--- a/packages/schema-dts-gen/test/helpers/make_class.ts
+++ b/packages/schema-dts-gen/test/helpers/make_class.ts
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {UrlNode} from '../../src/triples/types.js';
+import {Property, PropertyType} from '../../src/index.js';
+import {NamedUrlNode, UrlNode} from '../../src/triples/types.js';
 import {Class, ClassMap} from '../../src/ts/class.js';
 
 export function makeClass(url: string): Class {
-  return new Class(UrlNode.Parse(url));
+  return new Class(UrlNode.Parse(url) as NamedUrlNode);
+}
+
+export function makeProperty(url: string): Property {
+  const u = UrlNode.Parse(url);
+  return new Property(u, new PropertyType(u));
 }
 
 export function makeClassMap(...classes: Class[]): ClassMap {

--- a/packages/schema-dts-gen/test/triples/types_test.ts
+++ b/packages/schema-dts-gen/test/triples/types_test.ts
@@ -47,35 +47,15 @@ describe('UrlNode', () => {
     expect(node.context.path).toEqual(['']);
   });
 
-  it('rejects search strings', () => {
-    expect(() =>
-      UrlNode.Parse('http://schema.org/Person?q=true&a')
-    ).toThrowError('Search string');
-
-    expect(() => UrlNode.Parse('http://schema.org/Person?q&a')).toThrowError(
-      'Search string'
-    );
-
-    expect(() => UrlNode.Parse('http://schema.org/Person?q')).toThrowError(
-      'Search string'
-    );
-
-    expect(() =>
-      UrlNode.Parse('http://schema.org/abc?q#foo')
-    ).not.toThrowError();
-    expect(() => UrlNode.Parse('http://schema.org/abc#?q')).not.toThrowError();
+  it('treats search strings as unnamed', () => {
+    const node = UrlNode.Parse('http://schema.org/Person?q=true&a');
+    expect(node.name).toBeUndefined();
+    expect(node.context.href).toBe('http://schema.org/Person?q=true&a');
   });
 
-  it('top-level domain', () => {
-    expect(() => UrlNode.Parse('http://schema.org/')).toThrowError(
-      "no room for 'name'"
-    );
-
-    expect(() => UrlNode.Parse('http://schema.org')).toThrowError(
-      "no room for 'name'"
-    );
-
-    expect(() => UrlNode.Parse('http://schema.org/#foo')).not.toThrowError();
+  it('treats top-level domain as unnamed', () => {
+    expect(UrlNode.Parse('http://schema.org/').name).toBeUndefined();
+    expect(UrlNode.Parse('http://schema.org').name).toBeUndefined();
   });
 
   describe('matches context', () => {

--- a/packages/schema-dts-gen/test/ts/context_test.ts
+++ b/packages/schema-dts-gen/test/ts/context_test.ts
@@ -143,6 +143,13 @@ describe('Context.getScopedName', () => {
     expect(ctx.getScopedName(UrlNode.Parse('https://foo.org/Door'))).toBe(
       'https://foo.org/Door'
     );
+
+    expect(ctx.getScopedName(UrlNode.Parse('https://schema.org/'))).toBe(
+      'https://schema.org/'
+    );
+    expect(ctx.getScopedName(UrlNode.Parse('https://schema.org'))).toBe(
+      'https://schema.org/'
+    );
   });
 
   it('with single domain URL (http)', () => {
@@ -184,6 +191,12 @@ describe('Context.getScopedName', () => {
     ).toBe('rdfs:subClassOf');
     expect(ctx.getScopedName(UrlNode.Parse('http://foo.org/Door'))).toBe(
       'http://foo.org/Door'
+    );
+    expect(ctx.getScopedName(UrlNode.Parse('http://schema.org/'))).toBe(
+      'schema:'
+    );
+    expect(ctx.getScopedName(UrlNode.Parse('http://schema.org'))).toBe(
+      'schema:'
     );
   });
 });

--- a/packages/schema-dts-gen/test/ts/names_test.ts
+++ b/packages/schema-dts-gen/test/ts/names_test.ts
@@ -13,43 +13,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {UrlNode} from '../../src/triples/types.js';
+import {NamedUrlNode, UrlNode} from '../../src/triples/types.js';
 import {toClassName} from '../../src/ts/util/names.js';
+
+function parseNamed(url: string): NamedUrlNode {
+  return UrlNode.Parse(url) as NamedUrlNode;
+}
 
 describe('toClassName', () => {
   it('operates normally, with typical inputs', () => {
-    expect(toClassName(UrlNode.Parse('https://schema.org/Person'))).toBe(
-      'Person'
-    );
-    expect(toClassName(UrlNode.Parse('https://schema.org/Person3'))).toBe(
+    expect(toClassName(parseNamed('https://schema.org/Person'))).toBe('Person');
+    expect(toClassName(parseNamed('https://schema.org/Person3'))).toBe(
       'Person3'
     );
-    expect(toClassName(UrlNode.Parse('http://schema.org/Person'))).toBe(
-      'Person'
-    );
+    expect(toClassName(parseNamed('http://schema.org/Person'))).toBe('Person');
     expect(
-      toClassName(UrlNode.Parse('http://schema.org/Organization4Organization'))
+      toClassName(parseNamed('http://schema.org/Organization4Organization'))
     ).toBe('Organization4Organization');
   });
 
   it('handles illegal TypeScript identifier characters', () => {
-    expect(toClassName(UrlNode.Parse('https://schema.org/Person-4'))).toBe(
+    expect(toClassName(parseNamed('https://schema.org/Person-4'))).toBe(
       'Person_4'
     );
-    expect(toClassName(UrlNode.Parse('https://schema.org/Person%4'))).toBe(
+    expect(toClassName(parseNamed('https://schema.org/Person%4'))).toBe(
       'Person_4'
     );
-    expect(toClassName(UrlNode.Parse('https://schema.org/Person%204'))).toBe(
+    expect(toClassName(parseNamed('https://schema.org/Person%204'))).toBe(
       'Person_4'
     );
-    expect(toClassName(UrlNode.Parse('https://schema.org/Person, 4'))).toBe(
+    expect(toClassName(parseNamed('https://schema.org/Person, 4'))).toBe(
       'Person__4'
     );
 
-    expect(toClassName(UrlNode.Parse('https://schema.org/3DModel'))).toBe(
+    expect(toClassName(parseNamed('https://schema.org/3DModel'))).toBe(
       '_3DModel'
     );
-    expect(toClassName(UrlNode.Parse('https://schema.org/3DModel-5'))).toBe(
+    expect(toClassName(parseNamed('https://schema.org/3DModel-5'))).toBe(
       '_3DModel_5'
     );
   });


### PR DESCRIPTION
1. Support URL nodes with no "name"
2. Support URL nodes with search query string
3. Understand native rdfs:domain and rdfs:range directives
4. Do not treat OWL Class/Property & other ontology declarations as enum
   membership
5. Context support for unnamed URLs ("schema:" is totally valid)
6. Allow type=Class to be transitive
7. Support 1-char long strings

This begins building support for #169