### PR TITLE
Remove use of observables in schema-dts, use plain old promises instead.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6305,14 +6305,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -6834,11 +6826,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -7378,7 +7365,6 @@
         "remark-parse": "^10.0.1",
         "remark-rehype": "^10.1.0",
         "remark-wiki-link": "^1.0.4",
-        "rxjs": "^7.5.4",
         "unified": "^10.1.1"
       },
       "bin": {
@@ -12007,14 +11993,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rxjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -12063,7 +12041,6 @@
         "remark-parse": "^10.0.1",
         "remark-rehype": "^10.1.0",
         "remark-wiki-link": "^1.0.4",
-        "rxjs": "^7.5.4",
         "unified": "^10.1.1"
       },
       "dependencies": {
@@ -12432,11 +12409,6 @@
           "dev": true
         }
       }
-    },
-    "tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/packages/schema-dts-gen/package.json
+++ b/packages/schema-dts-gen/package.json
@@ -40,7 +40,6 @@
     "remark-parse": "^10.0.1",
     "remark-rehype": "^10.1.0",
     "remark-wiki-link": "^1.0.4",
-    "rxjs": "^7.5.4",
     "unified": "^10.1.1"
   },
   "engines": {

--- a/packages/schema-dts-gen/src/cli/internal/main.ts
+++ b/packages/schema-dts-gen/src/cli/internal/main.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Observable} from 'rxjs';
 import {Triple} from '../..';
 import {Log, SetOptions} from '../../logging/index.js';
 import {WriteDeclarations} from '../../transform/transform.js';
@@ -29,14 +28,14 @@ export async function main(write: (s: string) => void, args?: string[]) {
 
   const ontologyUrl = options.ontology;
   const filePath = options.file;
-  let result: Observable<Triple>;
+  let result: Triple[];
 
   if (filePath) {
     Log(`Loading Ontology from path: ${filePath}`);
-    result = loadFile(filePath);
+    result = await loadFile(filePath);
   } else {
     Log(`Loading Ontology from URL: ${ontologyUrl}`);
-    result = load(ontologyUrl);
+    result = await load(ontologyUrl);
   }
   const context = Context.Parse(options.context);
   await WriteDeclarations(result, options.deprecated, context, write);

--- a/packages/schema-dts-gen/src/transform/transform.ts
+++ b/packages/schema-dts-gen/src/transform/transform.ts
@@ -23,8 +23,6 @@ const {
   ScriptTarget,
 } = ts;
 
-import {firstValueFrom, Observable} from 'rxjs';
-
 import {asTopicArray} from '../triples/operators.js';
 import {Triple} from '../triples/triple.js';
 import {Sort} from '../ts/class.js';
@@ -49,12 +47,12 @@ import {HelperTypes} from '../ts/helper_types.js';
  * @returns Promise indicating completion.
  */
 export async function WriteDeclarations(
-  triples: Observable<Triple>,
+  triples: Triple[],
   includeDeprecated: boolean,
   context: Context,
   write: (content: string) => Promise<void> | void
 ) {
-  const topics = await firstValueFrom(triples.pipe(asTopicArray()));
+  const topics = asTopicArray(triples);
 
   const classes = ProcessClasses(topics);
   ProcessProperties(topics, classes);

--- a/packages/schema-dts-gen/test/cli/args_logmessages_test.ts
+++ b/packages/schema-dts-gen/test/cli/args_logmessages_test.ts
@@ -16,8 +16,7 @@
  */
 import {jest} from '@jest/globals';
 
-import {Readable} from 'stream';
-import fs from 'fs';
+import fs from 'fs/promises';
 import {main} from '../../src/cli/internal/main.js';
 import {SetLogger} from '../../src/logging/index.js';
 
@@ -27,11 +26,9 @@ describe('main Args logs', () => {
 
   beforeEach(() => {
     const mockFileLine = `<http://schema.org/Thing> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .\n`;
-    const mockedStream = Readable.from([mockFileLine]);
     jest
-      .spyOn(fs, 'createReadStream')
-      //@ts-ignore
-      .mockImplementation(path => mockedStream);
+      .spyOn(fs, 'readFile')
+      .mockImplementation(_ => Promise.resolve(mockFileLine));
 
     logs = [];
     ResetLogger = SetLogger(msg => logs.push(msg));


### PR DESCRIPTION
rxjs is great, but our parsing already required us to collect the entire
file as a string before parsing it, so there aren't as many benefits of
"streaming" the resultant triples.