### PR TITLE
Remove TypeScript as an explicit peer dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You will usually want your top-level item to include a `@context`, like
 can augment it with `WithContext`, e.g.:
 
 ```ts
-import {Person, WithContext} from 'schema-dts';
+import type {Person, WithContext} from 'schema-dts';
 
 const p: WithContext<Person> = {
   '@context': 'https://schema.org',
@@ -75,7 +75,7 @@ their parent. Other objects are defined at the top-level with an `@id`, because
 multiple nodes refer to them.
 
 ```ts
-import {Graph} from 'schema-dts';
+import type {Graph} from 'schema-dts';
 
 const graph: Graph = {
   '@context': 'https://schema.org',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,6 @@
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=7.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.5.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7045,9 +7042,6 @@
       "devDependencies": {
         "mkdirp": "^1.0.4",
         "schema-dts-gen": "*"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.1.0"
       }
     },
     "packages/schema-dts-gen": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7037,7 +7037,7 @@
       }
     },
     "packages/schema-dts": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "npm": ">=7.0.0"
   },
   "engineStrict": true,
-  "peerDependencies": {
-    "typescript": ">=4.5.5"
-  },
   "nyc": {
     "extension": [
       ".ts",

--- a/packages/schema-dts/README.md
+++ b/packages/schema-dts/README.md
@@ -31,7 +31,7 @@ Then you can use it by importing `"schema-dts"`.
 ### Defining Simple Properties
 
 ```ts
-import {Person} from 'schema-dts';
+import type {Person} from 'schema-dts';
 
 const inventor: Person = {
   '@type': 'Person',
@@ -54,7 +54,7 @@ to describe the URIs represeting the types and properties being referenced.
 schema-dts provides the `WithContext<T>` type to facilitate this.
 
 ```ts
-import {Organization, Thing, WithContext} from 'schema-dts';
+import type {Organization, Thing, WithContext} from 'schema-dts';
 
 export function JsonLd<T extends Thing>(json: WithContext<T>): string {
   return `<script type="application/ld+json">
@@ -87,7 +87,7 @@ their parent. Other objects are defined at the top-level with an `@id`, because
 multiple nodes refer to them.
 
 ```ts
-import {Graph} from 'schema-dts';
+import type {Graph} from 'schema-dts';
 
 const graph: Graph = {
   '@context': 'https://schema.org',

--- a/packages/schema-dts/package.json
+++ b/packages/schema-dts/package.json
@@ -22,9 +22,6 @@
     "mkdirp": "^1.0.4",
     "schema-dts-gen": "*"
   },
-  "peerDependencies": {
-    "typescript": ">=4.1.0"
-  },
   "keywords": [
     "typescript",
     "tsd",

--- a/packages/schema-dts/package.json
+++ b/packages/schema-dts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-dts",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "displayName": "schema-dts: Strongly-typed Schema.org vocabulary declarations",
   "description": "A TypeScript package with latest Schema.org Schema Typings",
   "author": "Eyas Sharaiha <eyas@google.com> (https://eyas.sh/)",


### PR DESCRIPTION
This is one potential fix to #180 that allows schema-dts to continue to be used
with `import` and any/no bundlers without increasing bundle size.

It is also possible to address #180 by simply asking users to save
schema-dts as a dev dependency. This is generally more correct for
typings, but runs the risk of leaving dangling imports to nonexistent
"schema-dts" js.