### PR TITLE
Support Input and Output constraints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "eslint.options": {
-    "configFile": "./.eslintrc.cjs"
+    "overrideConfigFile": "./.eslintrc.cjs"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[typescript]": {

--- a/README.md
+++ b/README.md
@@ -117,6 +117,35 @@ const graph: Graph = {
 };
 ```
 
+### Input and Output constraints
+
+Actions support additional information to describe inputs and outputs, so each
+property can be annotated using `-input` and `-output` suffixes and you can do
+that in `schema-dts` by using the `WithActionConstraints` type for each action
+type you want to annotate. See the following examples:
+
+```ts
+import type {SearchAction, WithActionConstraints} from 'schema-dts';
+
+const potentialAction: WithActionConstraints<SearchAction> = {
+  '@type': 'SearchAction',
+  'query-input': 'required name=search_term_string',
+  // ...
+};
+```
+
+```ts
+import type {SearchAction, WebSite, WithActionConstraints} from 'schema-dts';
+
+const website: WebSite = {
+  '@type': 'WebSite',
+  potentialAction: {
+    '@type': 'SearchAction',
+    'query-input': 'required name=search_term_string',
+  } as WithActionConstraints<SearchAction>,
+};
+```
+
 # Schema Typings Generator
 
 The Schema Typings Generator is available in the

--- a/packages/schema-dts-gen/src/ts/action_constraints.ts
+++ b/packages/schema-dts-gen/src/ts/action_constraints.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ts, {factory, ModifierFlags, SyntaxKind} from 'typescript';
+import {arrayOf} from './util/arrayof.js';
+import {withComments} from './util/comments.js';
+
+const ActionBaseName = 'ActionBase';
+const InputActionConstraintsName = 'InputActionConstraints';
+const OutputActionConstraintsName = 'OutputActionConstraints';
+
+function createIOActionConstraints(
+  suffix: 'input' | 'output',
+): ts.TypeAliasDeclaration {
+  const name =
+    suffix === 'input'
+      ? InputActionConstraintsName
+      : OutputActionConstraintsName;
+  return factory.createTypeAliasDeclaration(
+    undefined,
+    name,
+    arrayOf(
+      factory.createTypeParameterDeclaration(
+        [],
+        'T',
+        factory.createTypeReferenceNode(ActionBaseName),
+      ),
+    ),
+    factory.createTypeReferenceNode('Partial', [
+      factory.createMappedTypeNode(
+        undefined,
+        factory.createTypeParameterDeclaration(
+          undefined,
+          'K',
+          factory.createTypeReferenceNode('Exclude', [
+            factory.createTypeOperatorNode(
+              SyntaxKind.KeyOfKeyword,
+              factory.createTypeReferenceNode('T'),
+            ),
+            factory.createTemplateLiteralType(factory.createTemplateHead('@'), [
+              factory.createTemplateLiteralTypeSpan(
+                factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+                factory.createTemplateTail(''),
+              ),
+            ]),
+          ]),
+        ),
+        factory.createTemplateLiteralType(factory.createTemplateHead(''), [
+          factory.createTemplateLiteralTypeSpan(
+            factory.createIntersectionTypeNode([
+              factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+              factory.createTypeReferenceNode('K'),
+            ]),
+            factory.createTemplateTail(`-${suffix}`),
+          ),
+        ]),
+        undefined,
+        factory.createUnionTypeNode([
+          factory.createTypeReferenceNode('PropertyValueSpecification'),
+          factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+        ]),
+        undefined,
+      ),
+    ]),
+  );
+}
+
+export const InputActionConstraintsType = createIOActionConstraints('input');
+export const OutputActionConstraintsType = createIOActionConstraints('output');
+export const WithActionConstraintsType = withComments(
+  'Provides input and output action constraints for an action.',
+  factory.createTypeAliasDeclaration(
+    factory.createModifiersFromModifierFlags(ModifierFlags.Export),
+    'WithActionConstraints',
+    arrayOf(
+      factory.createTypeParameterDeclaration(
+        [],
+        'T',
+        factory.createTypeReferenceNode(ActionBaseName),
+      ),
+    ),
+    factory.createIntersectionTypeNode([
+      factory.createTypeReferenceNode('T'),
+      factory.createTypeReferenceNode(InputActionConstraintsName, [
+        factory.createTypeReferenceNode('T'),
+      ]),
+      factory.createTypeReferenceNode(OutputActionConstraintsName, [
+        factory.createTypeReferenceNode('T'),
+      ]),
+    ]),
+  ),
+);

--- a/packages/schema-dts-gen/src/ts/helper_types.ts
+++ b/packages/schema-dts-gen/src/ts/helper_types.ts
@@ -2,9 +2,14 @@ import ts from 'typescript';
 import type {TypeNode} from 'typescript';
 const {factory, SyntaxKind, ModifierFlags} = ts;
 
+import {
+  WithActionConstraintsType,
+  InputActionConstraintsType,
+  OutputActionConstraintsType,
+} from './action_constraints.js';
 import {Context} from './context.js';
-import {arrayOf} from './util/arrayof.js';
 
+import {arrayOf} from './util/arrayof.js';
 import {withComments} from './util/comments.js';
 import {typeUnion} from './util/union.js';
 
@@ -144,5 +149,8 @@ export function HelperTypes(context: Context, {hasRole}: {hasRole: boolean}) {
       /*typeParameters=*/ [],
       factory.createTypeLiteralNode([IdPropertyNode()]),
     ),
+    InputActionConstraintsType,
+    OutputActionConstraintsType,
+    WithActionConstraintsType,
   ];
 }

--- a/packages/schema-dts-gen/test/baselines/category_test.ts
+++ b/packages/schema-dts-gen/test/baselines/category_test.ts
@@ -45,38 +45,46 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = string;
+export type Text = string;
 
-    interface DistilleryLeaf extends ThingBase {
-        "@type": "Distillery";
-    }
-    /** A distillery. */
-    export type Distillery = DistilleryLeaf;
+interface DistilleryLeaf extends ThingBase {
+    "@type": "Distillery";
+}
+/** A distillery. */
+export type Distillery = DistilleryLeaf;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | Distillery;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | Distillery;
 
-    "
-  `);
+"
+`);
   expect(actualLogs).toMatchInlineSnapshot(`
     "Loading Ontology from URL: https://fake.com/category_test.ts.nt
     Got Response 200: Ok.

--- a/packages/schema-dts-gen/test/baselines/comments_test.ts
+++ b/packages/schema-dts-gen/test/baselines/comments_test.ts
@@ -65,87 +65,95 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
+/**
+ * Data type: Number.
+ *
+ * Usage guidelines:
+ * - Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+ * - Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.
+ */
+export type Number = number | \`\${number}\`;
+
+/** Data type: Text. */
+export type Text = string;
+
+interface ThingBase extends Partial<IdReference> {
     /**
-     * Data type: Number.
+     * Media type typically expressed using a MIME format (see {@link http://www.iana.org/assignments/media-types/media-types.xhtml IANA site} and {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types MDN reference}) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).
      *
-     * Usage guidelines:
-     * - Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.
-     * - Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.
+     * In cases where a {@link https://schema.org/CreativeWork CreativeWork} has several media type representations, {@link https://schema.org/encoding encoding} can be used to indicate each {@link https://schema.org/MediaObject MediaObject} alongside particular {@link https://schema.org/encodingFormat encodingFormat} information.
+     *
+     * Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
      */
-    export type Number = number | \`\${number}\`;
-
-    /** Data type: Text. */
-    export type Text = string;
-
-    interface ThingBase extends Partial<IdReference> {
-        /**
-         * Media type typically expressed using a MIME format (see {@link http://www.iana.org/assignments/media-types/media-types.xhtml IANA site} and {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types MDN reference}) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).
-         *
-         * In cases where a {@link https://schema.org/CreativeWork CreativeWork} has several media type representations, {@link https://schema.org/encoding encoding} can be used to indicate each {@link https://schema.org/MediaObject MediaObject} alongside particular {@link https://schema.org/encodingFormat encodingFormat} information.
-         *
-         * Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
-         */
-        "encodingFormat"?: SchemaValue<Text>;
-        /**
-         * Reminds me of this quote:
-         * \`Foo Bar\`
-         *
-         * \`\`\`
-         * Hey!
-         * \`\`\`
-         * this.
-         */
-        "knows"?: SchemaValue<Text>;
-        /** Names are great! {@link X Y} */
-        "name"?: SchemaValue<Text>;
-        /** Names are great! {@link X Y} */
-        "name2"?: SchemaValue<Text>;
-        /** {@link https://schema.org/Link Link}s {@link https://schema.org/URL Aliased} */
-        "name3"?: SchemaValue<Text>;
-        /**
-         * \`\`\`
-         * Some code block
-         *
-         * \`\`\`
-         *
-         * Text.
-         */
-        "name4"?: SchemaValue<Text>;
-        /**
-         * The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'.
-         * - Days are specified using the following two-letter combinations: \`Mo\`, \`Tu\`, \`We\`, \`Th\`, \`Fr\`, \`Sa\`, \`Su\`.
-         * - Times are specified using 24:00 format. For example, 3pm is specified as \`15:00\`, 10am as \`10:00\`.
-         * - Here is an example: \`<time itemprop="openingHours" datetime="Tu,Th 16:00-20:00">Tuesdays and Thursdays 4-8pm</time>\`.
-         * - If a business is open 7 days a week, then it can be specified as \`<time itemprop="openingHours" datetime="Mo-Su">Monday through Sunday, all day</time>\`.
-         */
-        "openingHours"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
+    "encodingFormat"?: SchemaValue<Text>;
     /**
-     * Things are amazing!
+     * Reminds me of this quote:
+     * \`Foo Bar\`
      *
-     * - Foo
-     * - Bar
-     * - _Baz_, and __Bat__
+     * \`\`\`
+     * Hey!
+     * \`\`\`
+     * this.
      */
-    export type Thing = ThingLeaf;
+    "knows"?: SchemaValue<Text>;
+    /** Names are great! {@link X Y} */
+    "name"?: SchemaValue<Text>;
+    /** Names are great! {@link X Y} */
+    "name2"?: SchemaValue<Text>;
+    /** {@link https://schema.org/Link Link}s {@link https://schema.org/URL Aliased} */
+    "name3"?: SchemaValue<Text>;
+    /**
+     * \`\`\`
+     * Some code block
+     *
+     * \`\`\`
+     *
+     * Text.
+     */
+    "name4"?: SchemaValue<Text>;
+    /**
+     * The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'.
+     * - Days are specified using the following two-letter combinations: \`Mo\`, \`Tu\`, \`We\`, \`Th\`, \`Fr\`, \`Sa\`, \`Su\`.
+     * - Times are specified using 24:00 format. For example, 3pm is specified as \`15:00\`, 10am as \`10:00\`.
+     * - Here is an example: \`<time itemprop="openingHours" datetime="Tu,Th 16:00-20:00">Tuesdays and Thursdays 4-8pm</time>\`.
+     * - If a business is open 7 days a week, then it can be specified as \`<time itemprop="openingHours" datetime="Mo-Su">Monday through Sunday, all day</time>\`.
+     */
+    "openingHours"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+/**
+ * Things are amazing!
+ *
+ * - Foo
+ * - Bar
+ * - _Baz_, and __Bat__
+ */
+export type Thing = ThingLeaf;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/data_type_union_test.ts
+++ b/packages/schema-dts-gen/test/baselines/data_type_union_test.ts
@@ -43,36 +43,44 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Number = number | \`\${number}\`;
+export type Number = number | \`\${number}\`;
 
-    export type Text = string;
+export type Text = string;
 
-    /** The basic data types such as Integers, Strings, etc. */
-    export type DataType = Number | Text;
+/** The basic data types such as Integers, Strings, etc. */
+export type DataType = Number | Text;
 
-    interface ThingBase extends Partial<IdReference> {
-        "age"?: SchemaValue<Number>;
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf;
+interface ThingBase extends Partial<IdReference> {
+    "age"?: SchemaValue<Number>;
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/default_ontology_test.ts
+++ b/packages/schema-dts-gen/test/baselines/default_ontology_test.ts
@@ -30,29 +30,37 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    interface ThingBase extends Partial<IdReference> {
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf;
+interface ThingBase extends Partial<IdReference> {
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf;
 
-    "
-  `);
+"
+`);
   expect(actualLogs).toMatchInlineSnapshot(`
     "Loading Ontology from URL: https://schema.org/version/latest/schemaorg-all-https.nt
     Got Response 200: Ok.

--- a/packages/schema-dts-gen/test/baselines/deprecated_objects_test.ts
+++ b/packages/schema-dts-gen/test/baselines/deprecated_objects_test.ts
@@ -66,72 +66,80 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Number = number | \`\${number}\`;
+export type Number = number | \`\${number}\`;
 
-    export type Text = string;
+export type Text = string;
 
-    interface CarBase extends ThingBase {
-        "doorNumber"?: SchemaValue<Number>;
-    }
-    interface CarLeaf extends CarBase {
-        "@type": "Car";
-    }
-    export type Car = CarLeaf;
+interface CarBase extends ThingBase {
+    "doorNumber"?: SchemaValue<Number>;
+}
+interface CarLeaf extends CarBase {
+    "@type": "Car";
+}
+export type Car = CarLeaf;
 
-    interface PersonLikeBase extends ThingBase {
-        "height"?: SchemaValue<Number>;
-    }
-    interface PersonLikeLeaf extends PersonLikeBase {
-        "@type": "PersonLike";
-    }
-    export type PersonLike = PersonLikeLeaf;
+interface PersonLikeBase extends ThingBase {
+    "height"?: SchemaValue<Number>;
+}
+interface PersonLikeLeaf extends PersonLikeBase {
+    "@type": "PersonLike";
+}
+export type PersonLike = PersonLikeLeaf;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-        /**
-         * Names are great! {@link X Y}
-         *
-         * @deprecated Consider using http://schema.org/name or http://schema.org/height instead.
-         */
-        "names"?: SchemaValue<Text>;
-        /**
-         * Names are great!
-         * {@link X Y}
-         *
-         * @deprecated Consider using http://schema.org/name instead.
-         */
-        "names2"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | Car | PersonLike | Vehicle;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+    /**
+     * Names are great! {@link X Y}
+     *
+     * @deprecated Consider using http://schema.org/name or http://schema.org/height instead.
+     */
+    "names"?: SchemaValue<Text>;
+    /**
+     * Names are great!
+     * {@link X Y}
+     *
+     * @deprecated Consider using http://schema.org/name instead.
+     */
+    "names2"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | Car | PersonLike | Vehicle;
 
-    interface VehicleBase extends ThingBase {
-        "doorNumber"?: SchemaValue<Number>;
-        /** @deprecated Consider using http://schema.org/doorNumber instead. */
-        "doors"?: SchemaValue<Number>;
-    }
-    interface VehicleLeaf extends VehicleBase {
-        "@type": "Vehicle";
-    }
-    /** @deprecated Use Car instead. */
-    export type Vehicle = VehicleLeaf;
+interface VehicleBase extends ThingBase {
+    "doorNumber"?: SchemaValue<Number>;
+    /** @deprecated Consider using http://schema.org/doorNumber instead. */
+    "doors"?: SchemaValue<Number>;
+}
+interface VehicleLeaf extends VehicleBase {
+    "@type": "Vehicle";
+}
+/** @deprecated Use Car instead. */
+export type Vehicle = VehicleLeaf;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/duplicate_comments_test.ts
+++ b/packages/schema-dts-gen/test/baselines/duplicate_comments_test.ts
@@ -47,43 +47,51 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = string;
+export type Text = string;
 
-    interface ThingBase extends Partial<IdReference> {
-        /**
-         * Names are great!
-         * {@link X Y}
-         */
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
+interface ThingBase extends Partial<IdReference> {
     /**
-     * Things are amazing!
-     *
-     * - Foo
-     * - Bar
-     * - _Baz_, and __Bat__
+     * Names are great!
+     * {@link X Y}
      */
-    export type Thing = "http://schema.org/Gadget" | "https://schema.org/Gadget" | "Gadget" | "http://schema.org/Widget" | "https://schema.org/Widget" | "Widget" | ThingLeaf;
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+/**
+ * Things are amazing!
+ *
+ * - Foo
+ * - Bar
+ * - _Baz_, and __Bat__
+ */
+export type Thing = "http://schema.org/Gadget" | "https://schema.org/Gadget" | "Gadget" | "http://schema.org/Widget" | "https://schema.org/Widget" | "Widget" | ThingLeaf;
 
-    "
-  `);
+"
+`);
   expect(actualLogs).toMatchInlineSnapshot(`
     "Loading Ontology from URL: https://fake.com/duplicate_comments_test.ts.nt
     Got Response 200: Ok.

--- a/packages/schema-dts-gen/test/baselines/enum_skipped_test.ts
+++ b/packages/schema-dts-gen/test/baselines/enum_skipped_test.ts
@@ -43,30 +43,38 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    interface ThingBase extends Partial<IdReference> {
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    /** A Thing! */
-    export type Thing = "http://schema.org/a" | "https://schema.org/a" | "a" | "http://schema.org/b" | "https://schema.org/b" | "b" | "http://schema.org/c" | "https://schema.org/c" | "c" | "http://schema.org/d" | "https://schema.org/d" | "d" | "https://schema.org/e" | "e" | "http://google.com/f" | "https://google.com/f" | ThingLeaf;
+interface ThingBase extends Partial<IdReference> {
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+/** A Thing! */
+export type Thing = "http://schema.org/a" | "https://schema.org/a" | "a" | "http://schema.org/b" | "https://schema.org/b" | "b" | "http://schema.org/c" | "https://schema.org/c" | "c" | "http://schema.org/d" | "https://schema.org/d" | "d" | "https://schema.org/e" | "e" | "http://google.com/f" | "https://google.com/f" | ThingLeaf;
 
-    "
-  `);
+"
+`);
   expect(actualLogs).toMatchInlineSnapshot(`
     "Loading Ontology from URL: https://fake.com/enum_skipped_test.ts.nt
     Got Response 200: Ok.

--- a/packages/schema-dts-gen/test/baselines/inheritance_multiple_test.ts
+++ b/packages/schema-dts-gen/test/baselines/inheritance_multiple_test.ts
@@ -47,48 +47,56 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Number = number | \`\${number}\`;
+export type Number = number | \`\${number}\`;
 
-    export type Text = string;
+export type Text = string;
 
-    interface PersonLikeBase extends ThingBase {
-        "height"?: SchemaValue<Number>;
-    }
-    interface PersonLikeLeaf extends PersonLikeBase {
-        "@type": "PersonLike";
-    }
-    export type PersonLike = PersonLikeLeaf;
+interface PersonLikeBase extends ThingBase {
+    "height"?: SchemaValue<Number>;
+}
+interface PersonLikeLeaf extends PersonLikeBase {
+    "@type": "PersonLike";
+}
+export type PersonLike = PersonLikeLeaf;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | PersonLike | Vehicle;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | PersonLike | Vehicle;
 
-    interface VehicleBase extends ThingBase {
-        "doors"?: SchemaValue<Number>;
-    }
-    interface VehicleLeaf extends VehicleBase {
-        "@type": "Vehicle";
-    }
-    export type Vehicle = VehicleLeaf;
+interface VehicleBase extends ThingBase {
+    "doors"?: SchemaValue<Number>;
+}
+interface VehicleLeaf extends VehicleBase {
+    "@type": "Vehicle";
+}
+export type Vehicle = VehicleLeaf;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/inheritance_one_test.ts
+++ b/packages/schema-dts-gen/test/baselines/inheritance_one_test.ts
@@ -42,40 +42,48 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Number = number | \`\${number}\`;
+export type Number = number | \`\${number}\`;
 
-    export type Text = string;
+export type Text = string;
 
-    interface PersonLikeBase extends ThingBase {
-        "height"?: SchemaValue<Number>;
-    }
-    interface PersonLikeLeaf extends PersonLikeBase {
-        "@type": "PersonLike";
-    }
-    export type PersonLike = PersonLikeLeaf;
+interface PersonLikeBase extends ThingBase {
+    "height"?: SchemaValue<Number>;
+}
+interface PersonLikeLeaf extends PersonLikeBase {
+    "@type": "PersonLike";
+}
+export type PersonLike = PersonLikeLeaf;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | PersonLike;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | PersonLike;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/nested_datatype_test.ts
+++ b/packages/schema-dts-gen/test/baselines/nested_datatype_test.ts
@@ -57,57 +57,65 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = PronounceableText | URL | string;
+export type Text = PronounceableText | URL | string;
 
-    interface ArabicTextBase extends PronounceableTextBase {
-        "arabicPhoneticText"?: SchemaValue<Text>;
-    }
-    interface ArabicTextLeaf extends ArabicTextBase {
-        "@type": "ArabicText";
-    }
-    export type ArabicText = ArabicTextLeaf | string;
+interface ArabicTextBase extends PronounceableTextBase {
+    "arabicPhoneticText"?: SchemaValue<Text>;
+}
+interface ArabicTextLeaf extends ArabicTextBase {
+    "@type": "ArabicText";
+}
+export type ArabicText = ArabicTextLeaf | string;
 
-    interface EnglishTextLeaf extends PronounceableTextBase {
-        "@type": "EnglishText";
-    }
-    export type EnglishText = EnglishTextLeaf | string;
+interface EnglishTextLeaf extends PronounceableTextBase {
+    "@type": "EnglishText";
+}
+export type EnglishText = EnglishTextLeaf | string;
 
-    export type FancyURL = string;
+export type FancyURL = string;
 
-    interface PronounceableTextBase extends Partial<IdReference> {
-        "phoneticText"?: SchemaValue<Text>;
-    }
-    interface PronounceableTextLeaf extends PronounceableTextBase {
-        "@type": "PronounceableText";
-    }
-    export type PronounceableText = PronounceableTextLeaf | ArabicText | EnglishText | string;
+interface PronounceableTextBase extends Partial<IdReference> {
+    "phoneticText"?: SchemaValue<Text>;
+}
+interface PronounceableTextLeaf extends PronounceableTextBase {
+    "@type": "PronounceableText";
+}
+export type PronounceableText = PronounceableTextLeaf | ArabicText | EnglishText | string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-        "pronunciation"?: SchemaValue<PronounceableText | IdReference>;
-        "website"?: SchemaValue<URL>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+    "pronunciation"?: SchemaValue<PronounceableText | IdReference>;
+    "website"?: SchemaValue<URL>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf;
 
-    export type URL = FancyURL | string;
+export type URL = FancyURL | string;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/nodeprecated_objects_test.ts
+++ b/packages/schema-dts-gen/test/baselines/nodeprecated_objects_test.ts
@@ -65,48 +65,56 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Number = number | \`\${number}\`;
+export type Number = number | \`\${number}\`;
 
-    export type Text = string;
+export type Text = string;
 
-    interface CarBase extends ThingBase {
-        "doorNumber"?: SchemaValue<Number>;
-    }
-    interface CarLeaf extends CarBase {
-        "@type": "Car";
-    }
-    export type Car = CarLeaf;
+interface CarBase extends ThingBase {
+    "doorNumber"?: SchemaValue<Number>;
+}
+interface CarLeaf extends CarBase {
+    "@type": "Car";
+}
+export type Car = CarLeaf;
 
-    interface PersonLikeBase extends ThingBase {
-        "height"?: SchemaValue<Number>;
-    }
-    interface PersonLikeLeaf extends PersonLikeBase {
-        "@type": "PersonLike";
-    }
-    export type PersonLike = PersonLikeLeaf;
+interface PersonLikeBase extends ThingBase {
+    "height"?: SchemaValue<Number>;
+}
+interface PersonLikeLeaf extends PersonLikeBase {
+    "@type": "PersonLike";
+}
+export type PersonLike = PersonLikeLeaf;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | Car | PersonLike;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | Car | PersonLike;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/owl_mixed_basic_test.ts
+++ b/packages/schema-dts-gen/test/baselines/owl_mixed_basic_test.ts
@@ -41,40 +41,48 @@ test(`baseline_mixedOWL1_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    /** Data type: Text. */
-    export type Text = string;
+/** Data type: Text. */
+export type Text = string;
 
-    interface PersonLeaf extends ThingBase {
-        "@type": "Person";
-    }
-    /** ABC */
-    export type Person = PersonLeaf | string;
+interface PersonLeaf extends ThingBase {
+    "@type": "Person";
+}
+/** ABC */
+export type Person = PersonLeaf | string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    /** ABC */
-    export type Thing = ThingLeaf | Person;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+/** ABC */
+export type Thing = ThingLeaf | Person;
 
-    "
-  `);
+"
+`);
 });
 
 test(`baseline_mixedOWL2_${basename(import.meta.url)}`, async () => {
@@ -98,40 +106,48 @@ test(`baseline_mixedOWL2_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    /** Data type: Text. */
-    export type Text = string;
+/** Data type: Text. */
+export type Text = string;
 
-    interface PersonLeaf extends ThingBase {
-        "@type": "Person";
-    }
-    /** ABC */
-    export type Person = PersonLeaf | string;
+interface PersonLeaf extends ThingBase {
+    "@type": "Person";
+}
+/** ABC */
+export type Person = PersonLeaf | string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    /** ABC */
-    export type Thing = ThingLeaf | Person;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+/** ABC */
+export type Thing = ThingLeaf | Person;
 
-    "
-  `);
+"
+`);
 });
 
 test(`baseline_OWLenum_${basename(import.meta.url)}`, async () => {
@@ -160,45 +176,53 @@ test(`baseline_OWLenum_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    /** Data type: Text. */
-    export type Text = string;
+/** Data type: Text. */
+export type Text = string;
 
-    interface MyEnumBase extends Partial<IdReference> {
-    }
-    interface MyEnumLeaf extends MyEnumBase {
-        "@type": "http://www.w3.org/2002/07/owl#MyEnum";
-    }
-    export type MyEnum = "http://www.w3.org/2002/07/owl#EnumValueA" | "https://www.w3.org/2002/07/owl#EnumValueA" | "http://www.w3.org/2002/07/owl#EnumValueB" | "https://www.w3.org/2002/07/owl#EnumValueB" | MyEnumLeaf;
+interface MyEnumBase extends Partial<IdReference> {
+}
+interface MyEnumLeaf extends MyEnumBase {
+    "@type": "http://www.w3.org/2002/07/owl#MyEnum";
+}
+export type MyEnum = "http://www.w3.org/2002/07/owl#EnumValueA" | "https://www.w3.org/2002/07/owl#EnumValueA" | "http://www.w3.org/2002/07/owl#EnumValueB" | "https://www.w3.org/2002/07/owl#EnumValueB" | MyEnumLeaf;
 
-    interface PersonLeaf extends ThingBase {
-        "@type": "Person";
-    }
-    /** ABC */
-    export type Person = PersonLeaf | string;
+interface PersonLeaf extends ThingBase {
+    "@type": "Person";
+}
+/** ABC */
+export type Person = PersonLeaf | string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    /** ABC */
-    export type Thing = ThingLeaf | Person;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+/** ABC */
+export type Thing = ThingLeaf | Person;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/property_edge_cases_test.ts
+++ b/packages/schema-dts-gen/test/baselines/property_edge_cases_test.ts
@@ -42,33 +42,41 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = string;
+export type Text = string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "knows"?: SchemaValue<never>;
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf;
+interface ThingBase extends Partial<IdReference> {
+    "knows"?: SchemaValue<never>;
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf;
 
-    "
-  `);
+"
+`);
   expect(actualLogs).toMatchInlineSnapshot(`
     "Loading Ontology from URL: https://fake.com/property_edge_cases_test.ts.nt
     Got Response 200: Ok.

--- a/packages/schema-dts-gen/test/baselines/quantities_test.ts
+++ b/packages/schema-dts-gen/test/baselines/quantities_test.ts
@@ -49,60 +49,68 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = string;
+export type Text = string;
 
-    interface DistanceLeaf extends ThingBase {
-        "@type": "Distance";
-    }
-    export type Distance = DistanceLeaf | string;
+interface DistanceLeaf extends ThingBase {
+    "@type": "Distance";
+}
+export type Distance = DistanceLeaf | string;
 
-    interface DurationLeaf extends ThingBase {
-        "@type": "Duration";
-    }
-    export type Duration = DurationLeaf | string;
+interface DurationLeaf extends ThingBase {
+    "@type": "Duration";
+}
+export type Duration = DurationLeaf | string;
 
-    interface EnergyLeaf extends ThingBase {
-        "@type": "Energy";
-    }
-    export type Energy = EnergyLeaf | string;
+interface EnergyLeaf extends ThingBase {
+    "@type": "Energy";
+}
+export type Energy = EnergyLeaf | string;
 
-    interface IntangibleLeaf extends ThingBase {
-        "@type": "Intangible";
-    }
-    export type Intangible = IntangibleLeaf | Quantity;
+interface IntangibleLeaf extends ThingBase {
+    "@type": "Intangible";
+}
+export type Intangible = IntangibleLeaf | Quantity;
 
-    interface MassLeaf extends ThingBase {
-        "@type": "Mass";
-    }
-    export type Mass = MassLeaf | string;
+interface MassLeaf extends ThingBase {
+    "@type": "Mass";
+}
+export type Mass = MassLeaf | string;
 
-    interface QuantityLeaf extends ThingBase {
-        "@type": "Quantity";
-    }
-    export type Quantity = QuantityLeaf | Distance | Duration | Energy | Mass | string;
+interface QuantityLeaf extends ThingBase {
+    "@type": "Quantity";
+}
+export type Quantity = QuantityLeaf | Distance | Duration | Energy | Mass | string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | Intangible;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | Intangible;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/role_inheritance_test.ts
+++ b/packages/schema-dts-gen/test/baselines/role_inheritance_test.ts
@@ -49,64 +49,72 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T, TProperty extends string> = T | Role<T, TProperty> | readonly (T | Role<T, TProperty>)[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T, TProperty extends string> = T | Role<T, TProperty> | readonly (T | Role<T, TProperty>)[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    interface DateTimeBase extends Partial<IdReference> {
-    }
-    interface DateTimeLeaf extends DateTimeBase {
-        "@type": "DateTime";
-    }
-    export type DateTime = DateTimeLeaf | string;
+interface DateTimeBase extends Partial<IdReference> {
+}
+interface DateTimeLeaf extends DateTimeBase {
+    "@type": "DateTime";
+}
+export type DateTime = DateTimeLeaf | string;
 
-    type OrganizationRoleLeaf<TContent, TProperty extends string> = RoleBase & {
-        "@type": "OrganizationRole";
-    } & {
-        [key in TProperty]: TContent;
-    };
-    export type OrganizationRole<TContent = never, TProperty extends string = never> = OrganizationRoleLeaf<TContent, TProperty>;
+type OrganizationRoleLeaf<TContent, TProperty extends string> = RoleBase & {
+    "@type": "OrganizationRole";
+} & {
+    [key in TProperty]: TContent;
+};
+export type OrganizationRole<TContent = never, TProperty extends string = never> = OrganizationRoleLeaf<TContent, TProperty>;
 
-    interface RoleBase extends ThingBase {
-        "startDate"?: SchemaValue<DateTime | IdReference, "startDate">;
-    }
-    type RoleLeaf<TContent, TProperty extends string> = RoleBase & {
-        "@type": "Role";
-    } & {
-        [key in TProperty]: TContent;
-    };
-    /**
-     * Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.
-     *
-     * See also {@link http://blog.schema.org/2014/06/introducing-role.html blog post}.
-     */
-    export type Role<TContent = never, TProperty extends string = never> = RoleLeaf<TContent, TProperty> | OrganizationRole<TContent, TProperty>;
+interface RoleBase extends ThingBase {
+    "startDate"?: SchemaValue<DateTime | IdReference, "startDate">;
+}
+type RoleLeaf<TContent, TProperty extends string> = RoleBase & {
+    "@type": "Role";
+} & {
+    [key in TProperty]: TContent;
+};
+/**
+ * Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.
+ *
+ * See also {@link http://blog.schema.org/2014/06/introducing-role.html blog post}.
+ */
+export type Role<TContent = never, TProperty extends string = never> = RoleLeaf<TContent, TProperty> | OrganizationRole<TContent, TProperty>;
 
-    export type Text = string;
+export type Text = string;
 
-    interface IntangibleLeaf extends ThingBase {
-        "@type": "Intangible";
-    }
-    export type Intangible = IntangibleLeaf | Role;
+interface IntangibleLeaf extends ThingBase {
+    "@type": "Intangible";
+}
+export type Intangible = IntangibleLeaf | Role;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text, "name">;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | Intangible;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text, "name">;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | Intangible;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/role_simple_test.ts
+++ b/packages/schema-dts-gen/test/baselines/role_simple_test.ts
@@ -46,57 +46,65 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T, TProperty extends string> = T | Role<T, TProperty> | readonly (T | Role<T, TProperty>)[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T, TProperty extends string> = T | Role<T, TProperty> | readonly (T | Role<T, TProperty>)[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    interface DateTimeBase extends Partial<IdReference> {
-    }
-    interface DateTimeLeaf extends DateTimeBase {
-        "@type": "DateTime";
-    }
-    export type DateTime = DateTimeLeaf | string;
+interface DateTimeBase extends Partial<IdReference> {
+}
+interface DateTimeLeaf extends DateTimeBase {
+    "@type": "DateTime";
+}
+export type DateTime = DateTimeLeaf | string;
 
-    interface RoleBase extends ThingBase {
-        "startDate"?: SchemaValue<DateTime | IdReference, "startDate">;
-    }
-    type RoleLeaf<TContent, TProperty extends string> = RoleBase & {
-        "@type": "Role";
-    } & {
-        [key in TProperty]: TContent;
-    };
-    /**
-     * Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.
-     *
-     * See also {@link http://blog.schema.org/2014/06/introducing-role.html blog post}.
-     */
-    export type Role<TContent = never, TProperty extends string = never> = RoleLeaf<TContent, TProperty>;
+interface RoleBase extends ThingBase {
+    "startDate"?: SchemaValue<DateTime | IdReference, "startDate">;
+}
+type RoleLeaf<TContent, TProperty extends string> = RoleBase & {
+    "@type": "Role";
+} & {
+    [key in TProperty]: TContent;
+};
+/**
+ * Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.
+ *
+ * See also {@link http://blog.schema.org/2014/06/introducing-role.html blog post}.
+ */
+export type Role<TContent = never, TProperty extends string = never> = RoleLeaf<TContent, TProperty>;
 
-    export type Text = string;
+export type Text = string;
 
-    interface IntangibleLeaf extends ThingBase {
-        "@type": "Intangible";
-    }
-    export type Intangible = IntangibleLeaf | Role;
+interface IntangibleLeaf extends ThingBase {
+    "@type": "Intangible";
+}
+export type Intangible = IntangibleLeaf | Role;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text, "name">;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | Intangible;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text, "name">;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | Intangible;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/simple_test.ts
+++ b/packages/schema-dts-gen/test/baselines/simple_test.ts
@@ -35,30 +35,38 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = string;
+export type Text = string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/sorted_enum_test.ts
+++ b/packages/schema-dts-gen/test/baselines/sorted_enum_test.ts
@@ -36,28 +36,36 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    interface ThingBase extends Partial<IdReference> {
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    /** A Thing! */
-    export type Thing = "http://schema.org/a" | "https://schema.org/a" | "a" | "http://schema.org/b" | "https://schema.org/b" | "b" | "http://schema.org/c" | "https://schema.org/c" | "c" | "http://schema.org/d" | "https://schema.org/d" | "d" | ThingLeaf;
+interface ThingBase extends Partial<IdReference> {
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+/** A Thing! */
+export type Thing = "http://schema.org/a" | "https://schema.org/a" | "a" | "http://schema.org/b" | "https://schema.org/b" | "b" | "http://schema.org/c" | "https://schema.org/c" | "c" | "http://schema.org/d" | "https://schema.org/d" | "d" | ThingLeaf;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/sorted_props_test.ts
+++ b/packages/schema-dts-gen/test/baselines/sorted_props_test.ts
@@ -44,33 +44,41 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = string;
+export type Text = string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "a"?: SchemaValue<Text>;
-        "b"?: SchemaValue<Text>;
-        "c"?: SchemaValue<Text>;
-        "d"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf;
+interface ThingBase extends Partial<IdReference> {
+    "a"?: SchemaValue<Text>;
+    "b"?: SchemaValue<Text>;
+    "c"?: SchemaValue<Text>;
+    "d"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/sorted_proptypes_test.ts
+++ b/packages/schema-dts-gen/test/baselines/sorted_proptypes_test.ts
@@ -52,40 +52,48 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Boolean = "http://schema.org/False" | "https://schema.org/False" | "False" | "http://schema.org/True" | "https://schema.org/True" | "True" | boolean;
+export type Boolean = "http://schema.org/False" | "https://schema.org/False" | "False" | "http://schema.org/True" | "https://schema.org/True" | "True" | boolean;
 
-    export type Date = string;
+export type Date = string;
 
-    export type DateTime = string;
+export type DateTime = string;
 
-    export type Number = number | \`\${number}\`;
+export type Number = number | \`\${number}\`;
 
-    export type Text = string;
+export type Text = string;
 
-    export type Time = string;
+export type Time = string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "a"?: SchemaValue<Boolean | Date | DateTime | Number | Text | Time>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf;
+interface ThingBase extends Partial<IdReference> {
+    "a"?: SchemaValue<Boolean | Date | DateTime | Number | Text | Time>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/stringlike_http_test.ts
+++ b/packages/schema-dts-gen/test/baselines/stringlike_http_test.ts
@@ -60,66 +60,74 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = URL | string;
+export type Text = URL | string;
 
-    interface EntryPointLeaf extends ThingBase {
-        "@type": "EntryPoint";
-    }
-    export type EntryPoint = EntryPointLeaf | string;
+interface EntryPointLeaf extends ThingBase {
+    "@type": "EntryPoint";
+}
+export type EntryPoint = EntryPointLeaf | string;
 
-    interface OrganizationBase extends ThingBase {
-        "locatedIn"?: SchemaValue<Place | IdReference>;
-        "owner"?: SchemaValue<Person | IdReference>;
-        "urlTemplate"?: SchemaValue<URL>;
-    }
-    interface OrganizationLeaf extends OrganizationBase {
-        "@type": "Organization";
-    }
-    export type Organization = OrganizationLeaf | string;
+interface OrganizationBase extends ThingBase {
+    "locatedIn"?: SchemaValue<Place | IdReference>;
+    "owner"?: SchemaValue<Person | IdReference>;
+    "urlTemplate"?: SchemaValue<URL>;
+}
+interface OrganizationLeaf extends OrganizationBase {
+    "@type": "Organization";
+}
+export type Organization = OrganizationLeaf | string;
 
-    interface PersonBase extends ThingBase {
-        "height"?: SchemaValue<Quantity | IdReference>;
-        "locatedIn"?: SchemaValue<Place | IdReference>;
-    }
-    interface PersonLeaf extends PersonBase {
-        "@type": "Person";
-    }
-    export type Person = PersonLeaf | string;
+interface PersonBase extends ThingBase {
+    "height"?: SchemaValue<Quantity | IdReference>;
+    "locatedIn"?: SchemaValue<Place | IdReference>;
+}
+interface PersonLeaf extends PersonBase {
+    "@type": "Person";
+}
+export type Person = PersonLeaf | string;
 
-    interface PlaceLeaf extends ThingBase {
-        "@type": "Place";
-    }
-    export type Place = PlaceLeaf | string;
+interface PlaceLeaf extends ThingBase {
+    "@type": "Place";
+}
+export type Place = PlaceLeaf | string;
 
-    interface QuantityLeaf extends ThingBase {
-        "@type": "Quantity";
-    }
-    export type Quantity = QuantityLeaf | string;
+interface QuantityLeaf extends ThingBase {
+    "@type": "Quantity";
+}
+export type Quantity = QuantityLeaf | string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 
-    export type URL = string;
+export type URL = string;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/stringlike_https_test.ts
+++ b/packages/schema-dts-gen/test/baselines/stringlike_https_test.ts
@@ -60,66 +60,74 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = URL | string;
+export type Text = URL | string;
 
-    interface EntryPointLeaf extends ThingBase {
-        "@type": "EntryPoint";
-    }
-    export type EntryPoint = EntryPointLeaf | string;
+interface EntryPointLeaf extends ThingBase {
+    "@type": "EntryPoint";
+}
+export type EntryPoint = EntryPointLeaf | string;
 
-    interface OrganizationBase extends ThingBase {
-        "locatedIn"?: SchemaValue<Place | IdReference>;
-        "owner"?: SchemaValue<Person | IdReference>;
-        "urlTemplate"?: SchemaValue<URL>;
-    }
-    interface OrganizationLeaf extends OrganizationBase {
-        "@type": "Organization";
-    }
-    export type Organization = OrganizationLeaf | string;
+interface OrganizationBase extends ThingBase {
+    "locatedIn"?: SchemaValue<Place | IdReference>;
+    "owner"?: SchemaValue<Person | IdReference>;
+    "urlTemplate"?: SchemaValue<URL>;
+}
+interface OrganizationLeaf extends OrganizationBase {
+    "@type": "Organization";
+}
+export type Organization = OrganizationLeaf | string;
 
-    interface PersonBase extends ThingBase {
-        "height"?: SchemaValue<Quantity | IdReference>;
-        "locatedIn"?: SchemaValue<Place | IdReference>;
-    }
-    interface PersonLeaf extends PersonBase {
-        "@type": "Person";
-    }
-    export type Person = PersonLeaf | string;
+interface PersonBase extends ThingBase {
+    "height"?: SchemaValue<Quantity | IdReference>;
+    "locatedIn"?: SchemaValue<Place | IdReference>;
+}
+interface PersonLeaf extends PersonBase {
+    "@type": "Person";
+}
+export type Person = PersonLeaf | string;
 
-    interface PlaceLeaf extends ThingBase {
-        "@type": "Place";
-    }
-    export type Place = PlaceLeaf | string;
+interface PlaceLeaf extends ThingBase {
+    "@type": "Place";
+}
+export type Place = PlaceLeaf | string;
 
-    interface QuantityLeaf extends ThingBase {
-        "@type": "Quantity";
-    }
-    export type Quantity = QuantityLeaf | string;
+interface QuantityLeaf extends ThingBase {
+    "@type": "Quantity";
+}
+export type Quantity = QuantityLeaf | string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | EntryPoint | Organization | Person | Place | Quantity;
 
-    export type URL = string;
+export type URL = string;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_test.ts
+++ b/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_test.ts
@@ -49,58 +49,66 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    interface EnumerationLeaf extends ThingBase {
-        "@type": "Enumeration";
-    }
-    export type Enumeration = EnumerationLeaf | MedicalEnumeration;
+interface EnumerationLeaf extends ThingBase {
+    "@type": "Enumeration";
+}
+export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
-    interface IntangibleLeaf extends ThingBase {
-        "@type": "Intangible";
-    }
-    export type Intangible = IntangibleLeaf | Enumeration;
+interface IntangibleLeaf extends ThingBase {
+    "@type": "Intangible";
+}
+export type Intangible = IntangibleLeaf | Enumeration;
 
-    interface MedicalEnumerationLeaf extends ThingBase {
-        "@type": "MedicalEnumeration";
-    }
-    export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
+interface MedicalEnumerationLeaf extends ThingBase {
+    "@type": "MedicalEnumeration";
+}
+export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
-    interface MedicalProcedureLeaf extends ThingBase {
-        "@type": "MedicalProcedure";
-    }
-    export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
+interface MedicalProcedureLeaf extends ThingBase {
+    "@type": "MedicalProcedure";
+}
+export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
-    interface MedicalProcedureTypeLeaf extends ThingBase {
-        "@type": "MedicalProcedureType";
-    }
-    export type MedicalProcedureType = "http://schema.org/SurgicalProcedure" | "https://schema.org/SurgicalProcedure" | "SurgicalProcedure" | MedicalProcedureTypeLeaf;
+interface MedicalProcedureTypeLeaf extends ThingBase {
+    "@type": "MedicalProcedureType";
+}
+export type MedicalProcedureType = "http://schema.org/SurgicalProcedure" | "https://schema.org/SurgicalProcedure" | "SurgicalProcedure" | MedicalProcedureTypeLeaf;
 
-    interface SurgicalProcedureLeaf extends ThingBase {
-        "@type": "SurgicalProcedure";
-    }
-    /** A type of medical procedure that involves invasive surgical techniques. */
-    export type SurgicalProcedure = SurgicalProcedureLeaf;
+interface SurgicalProcedureLeaf extends ThingBase {
+    "@type": "SurgicalProcedure";
+}
+/** A type of medical procedure that involves invasive surgical techniques. */
+export type SurgicalProcedure = SurgicalProcedureLeaf;
 
-    interface ThingBase extends Partial<IdReference> {
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | Intangible | MedicalProcedure;
+interface ThingBase extends Partial<IdReference> {
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | Intangible | MedicalProcedure;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -49,58 +49,66 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    interface EnumerationLeaf extends ThingBase {
-        "@type": "Enumeration";
-    }
-    export type Enumeration = EnumerationLeaf | MedicalEnumeration;
+interface EnumerationLeaf extends ThingBase {
+    "@type": "Enumeration";
+}
+export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
-    interface IntangibleLeaf extends ThingBase {
-        "@type": "Intangible";
-    }
-    export type Intangible = IntangibleLeaf | Enumeration;
+interface IntangibleLeaf extends ThingBase {
+    "@type": "Intangible";
+}
+export type Intangible = IntangibleLeaf | Enumeration;
 
-    interface MedicalEnumerationLeaf extends ThingBase {
-        "@type": "MedicalEnumeration";
-    }
-    export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
+interface MedicalEnumerationLeaf extends ThingBase {
+    "@type": "MedicalEnumeration";
+}
+export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType;
 
-    interface MedicalProcedureLeaf extends ThingBase {
-        "@type": "MedicalProcedure";
-    }
-    export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
+interface MedicalProcedureLeaf extends ThingBase {
+    "@type": "MedicalProcedure";
+}
+export type MedicalProcedure = MedicalProcedureLeaf | SurgicalProcedure;
 
-    interface MedicalProcedureTypeLeaf extends ThingBase {
-        "@type": "MedicalProcedureType";
-    }
-    export type MedicalProcedureType = "http://schema.org/SurgicalProcedure" | "https://schema.org/SurgicalProcedure" | "SurgicalProcedure" | MedicalProcedureTypeLeaf;
+interface MedicalProcedureTypeLeaf extends ThingBase {
+    "@type": "MedicalProcedureType";
+}
+export type MedicalProcedureType = "http://schema.org/SurgicalProcedure" | "https://schema.org/SurgicalProcedure" | "SurgicalProcedure" | MedicalProcedureTypeLeaf;
 
-    interface SurgicalProcedureLeaf extends ThingBase {
-        "@type": "SurgicalProcedure";
-    }
-    /** A type of medical procedure that involves invasive surgical techniques. */
-    export type SurgicalProcedure = SurgicalProcedureLeaf;
+interface SurgicalProcedureLeaf extends ThingBase {
+    "@type": "SurgicalProcedure";
+}
+/** A type of medical procedure that involves invasive surgical techniques. */
+export type SurgicalProcedure = SurgicalProcedureLeaf;
 
-    interface ThingBase extends Partial<IdReference> {
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | Intangible | MedicalProcedure;
+interface ThingBase extends Partial<IdReference> {
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | Intangible | MedicalProcedure;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/surgical_procedure_test.ts
+++ b/packages/schema-dts-gen/test/baselines/surgical_procedure_test.ts
@@ -74,95 +74,103 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    interface DiagnosticProcedureLeaf extends ThingBase {
-        "@type": "DiagnosticProcedure";
-    }
-    export type DiagnosticProcedure = DiagnosticProcedureLeaf;
+interface DiagnosticProcedureLeaf extends ThingBase {
+    "@type": "DiagnosticProcedure";
+}
+export type DiagnosticProcedure = DiagnosticProcedureLeaf;
 
-    interface EnumerationLeaf extends ThingBase {
-        "@type": "Enumeration";
-    }
-    export type Enumeration = EnumerationLeaf | MedicalEnumeration;
+interface EnumerationLeaf extends ThingBase {
+    "@type": "Enumeration";
+}
+export type Enumeration = EnumerationLeaf | MedicalEnumeration;
 
-    interface IntangibleLeaf extends ThingBase {
-        "@type": "Intangible";
-    }
-    export type Intangible = IntangibleLeaf | Enumeration;
+interface IntangibleLeaf extends ThingBase {
+    "@type": "Intangible";
+}
+export type Intangible = IntangibleLeaf | Enumeration;
 
-    interface MedicalEntityLeaf extends ThingBase {
-        "@type": "MedicalEntity";
-    }
-    export type MedicalEntity = MedicalEntityLeaf | MedicalProcedure;
+interface MedicalEntityLeaf extends ThingBase {
+    "@type": "MedicalEntity";
+}
+export type MedicalEntity = MedicalEntityLeaf | MedicalProcedure;
 
-    interface MedicalEnumerationLeaf extends ThingBase {
-        "@type": "MedicalEnumeration";
-    }
-    export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType | PhysicalExam;
+interface MedicalEnumerationLeaf extends ThingBase {
+    "@type": "MedicalEnumeration";
+}
+export type MedicalEnumeration = MedicalEnumerationLeaf | MedicalProcedureType | PhysicalExam;
 
-    interface MedicalProcedureLeaf extends ThingBase {
-        "@type": "MedicalProcedure";
-    }
-    /** A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques. */
-    export type MedicalProcedure = MedicalProcedureLeaf | DiagnosticProcedure | PalliativeProcedure | PhysicalExam | SurgicalProcedure | TherapeuticProcedure;
+interface MedicalProcedureLeaf extends ThingBase {
+    "@type": "MedicalProcedure";
+}
+/** A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques. */
+export type MedicalProcedure = MedicalProcedureLeaf | DiagnosticProcedure | PalliativeProcedure | PhysicalExam | SurgicalProcedure | TherapeuticProcedure;
 
-    interface MedicalProcedureTypeLeaf extends ThingBase {
-        "@type": "MedicalProcedureType";
-    }
-    /** An enumeration that describes different types of medical procedures. */
-    export type MedicalProcedureType = "http://schema.org/NoninvasiveProcedure" | "https://schema.org/NoninvasiveProcedure" | "NoninvasiveProcedure" | "http://schema.org/PercutaneousProcedure" | "https://schema.org/PercutaneousProcedure" | "PercutaneousProcedure" | MedicalProcedureTypeLeaf;
+interface MedicalProcedureTypeLeaf extends ThingBase {
+    "@type": "MedicalProcedureType";
+}
+/** An enumeration that describes different types of medical procedures. */
+export type MedicalProcedureType = "http://schema.org/NoninvasiveProcedure" | "https://schema.org/NoninvasiveProcedure" | "NoninvasiveProcedure" | "http://schema.org/PercutaneousProcedure" | "https://schema.org/PercutaneousProcedure" | "PercutaneousProcedure" | MedicalProcedureTypeLeaf;
 
-    interface MedicalTherapyLeaf extends ThingBase {
-        "@type": "MedicalTherapy";
-    }
-    export type MedicalTherapy = MedicalTherapyLeaf | PalliativeProcedure;
+interface MedicalTherapyLeaf extends ThingBase {
+    "@type": "MedicalTherapy";
+}
+export type MedicalTherapy = MedicalTherapyLeaf | PalliativeProcedure;
 
-    interface PalliativeProcedureBase extends ThingBase, ThingBase {
-    }
-    interface PalliativeProcedureLeaf extends PalliativeProcedureBase {
-        "@type": "PalliativeProcedure";
-    }
-    export type PalliativeProcedure = PalliativeProcedureLeaf;
+interface PalliativeProcedureBase extends ThingBase, ThingBase {
+}
+interface PalliativeProcedureLeaf extends PalliativeProcedureBase {
+    "@type": "PalliativeProcedure";
+}
+export type PalliativeProcedure = PalliativeProcedureLeaf;
 
-    interface PhysicalExamBase extends ThingBase, ThingBase {
-    }
-    interface PhysicalExamLeaf extends PhysicalExamBase {
-        "@type": "PhysicalExam";
-    }
-    export type PhysicalExam = "http://schema.org/Head" | "https://schema.org/Head" | "Head" | "http://schema.org/Neuro" | "https://schema.org/Neuro" | "Neuro" | PhysicalExamLeaf;
+interface PhysicalExamBase extends ThingBase, ThingBase {
+}
+interface PhysicalExamLeaf extends PhysicalExamBase {
+    "@type": "PhysicalExam";
+}
+export type PhysicalExam = "http://schema.org/Head" | "https://schema.org/Head" | "Head" | "http://schema.org/Neuro" | "https://schema.org/Neuro" | "Neuro" | PhysicalExamLeaf;
 
-    interface SurgicalProcedureLeaf extends ThingBase {
-        "@type": "SurgicalProcedure";
-    }
-    /** A medical procedure involving an incision with instruments; performed for diagnose, or therapeutic purposes. */
-    export type SurgicalProcedure = SurgicalProcedureLeaf;
+interface SurgicalProcedureLeaf extends ThingBase {
+    "@type": "SurgicalProcedure";
+}
+/** A medical procedure involving an incision with instruments; performed for diagnose, or therapeutic purposes. */
+export type SurgicalProcedure = SurgicalProcedureLeaf;
 
-    interface TherapeuticProcedureLeaf extends ThingBase {
-        "@type": "TherapeuticProcedure";
-    }
-    export type TherapeuticProcedure = TherapeuticProcedureLeaf | MedicalTherapy;
+interface TherapeuticProcedureLeaf extends ThingBase {
+    "@type": "TherapeuticProcedure";
+}
+export type TherapeuticProcedure = TherapeuticProcedureLeaf | MedicalTherapy;
 
-    interface ThingBase extends Partial<IdReference> {
-        "procedureType"?: SchemaValue<MedicalProcedureType | IdReference>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    export type Thing = ThingLeaf | Intangible | MedicalEntity;
+interface ThingBase extends Partial<IdReference> {
+    "procedureType"?: SchemaValue<MedicalProcedureType | IdReference>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+export type Thing = ThingLeaf | Intangible | MedicalEntity;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/transitive_class_test.ts
+++ b/packages/schema-dts-gen/test/baselines/transitive_class_test.ts
@@ -39,38 +39,46 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    /** Data type: Text. */
-    export type Text = string;
+/** Data type: Text. */
+export type Text = string;
 
-    interface PersonLeaf extends ThingBase {
-        "@type": "Person";
-    }
-    /** ABC */
-    export type Person = PersonLeaf | string;
+interface PersonLeaf extends ThingBase {
+    "@type": "Person";
+}
+/** ABC */
+export type Person = PersonLeaf | string;
 
-    interface ThingBase extends Partial<IdReference> {
-        "name"?: SchemaValue<Text>;
-    }
-    interface ThingLeaf extends ThingBase {
-        "@type": "Thing";
-    }
-    /** ABC */
-    export type Thing = ThingLeaf | Person;
+interface ThingBase extends Partial<IdReference> {
+    "name"?: SchemaValue<Text>;
+}
+interface ThingLeaf extends ThingBase {
+    "@type": "Thing";
+}
+/** ABC */
+export type Thing = ThingLeaf | Person;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts-gen/test/baselines/url_test.ts
+++ b/packages/schema-dts-gen/test/baselines/url_test.ts
@@ -35,25 +35,33 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
   );
 
   expect(actual).toMatchInlineSnapshot(`
-    "/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-    export type WithContext<T extends Thing> = T & {
-        "@context": "https://schema.org";
-    };
-    export interface Graph {
-        "@context": "https://schema.org";
-        "@graph": readonly Thing[];
-    }
-    type SchemaValue<T> = T | readonly T[];
-    type IdReference = {
-        /** IRI identifying the canonical address of this object. */
-        "@id": string;
-    };
+"/** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
+export type WithContext<T extends Thing> = T & {
+    "@context": "https://schema.org";
+};
+export interface Graph {
+    "@context": "https://schema.org";
+    "@graph": readonly Thing[];
+}
+type SchemaValue<T> = T | readonly T[];
+type IdReference = {
+    /** IRI identifying the canonical address of this object. */
+    "@id": string;
+};
+type InputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-input\`]: PropertyValueSpecification | string;
+}>;
+type OutputActionConstraints<T extends ActionBase> = Partial<{
+    [K in Exclude<keyof T, \`@\${string}\`> as \`\${string & K}-output\`]: PropertyValueSpecification | string;
+}>;
+/** Provides input and output action constraints for an action. */
+export type WithActionConstraints<T extends ActionBase> = T & InputActionConstraints<T> & OutputActionConstraints<T>;
 
-    export type Text = URL | string;
+export type Text = URL | string;
 
-    /** Data type: URL. */
-    export type URL = string;
+/** Data type: URL. */
+export type URL = string;
 
-    "
-  `);
+"
+`);
 });

--- a/packages/schema-dts/test/withactionconstraints.ts
+++ b/packages/schema-dts/test/withactionconstraints.ts
@@ -1,0 +1,29 @@
+import {SearchAction, WebSite, WithActionConstraints} from '../dist/schema';
+
+// @ts-expect-error Missing '@type'
+const _1: WithActionConstraints<SearchAction> = {};
+
+const _2: SearchAction = {
+  '@type': 'SearchAction',
+  // @ts-expect-error 'query-input' is not defined
+  'query-input': 'required name=search_term_string',
+};
+
+const _3: WithActionConstraints<SearchAction> = {
+  '@type': 'SearchAction',
+  'query-input': 'required name=search_term_string',
+};
+
+const _4: WithActionConstraints<SearchAction> = {
+  '@type': 'SearchAction',
+  // @ts-expect-error 'query-inputs' is not defined
+  'query-inputs': 'required name=search_term_string',
+};
+
+const _5: WebSite = {
+  '@type': 'WebSite',
+  potentialAction: {
+    '@type': 'SearchAction',
+    'query-input': 'required name=search_term_string',
+  } as WithActionConstraints<SearchAction>,
+};


### PR DESCRIPTION
According to the [docs](https://schema.org/docs/actions.html#part-4) actions can have input and output constraints.
This pull request adds a new helper `WithActionConstraints`, useful for those cases. fix #114

Usage example:
```ts
import type {SearchAction, WebSite, WithActionConstraints} from 'schema-dts';

const potentialAction: WithActionConstraints<SearchAction> = {
  '@type': 'SearchAction',
  'query-input': 'required name=search_term_string',
  // ...
};

const website: WebSite = {
  '@type': 'WebSite',
  potentialAction: {
    '@type': 'SearchAction',
    'query-input': 'required name=search_term_string',
  } as WithActionConstraints<SearchAction>,
};
```