### PR TITLE
Fix WithContext to exclude string members (#98)

### DIFF
--- a/packages/schema-dts-gen/src/ts/helper_types.ts
+++ b/packages/schema-dts-gen/src/ts/helper_types.ts
@@ -14,7 +14,7 @@ import {withComments} from './util/comments.js';
 import {typeUnion} from './util/union.js';
 
 function WithContextType(context: Context) {
-  // export interface WithContext<T extends JsonLdObject | string> extends Exclude<T, string> { "@context": TYPE_NODE }
+  // export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & { "@context": TYPE_NODE }
   return withComments(
     'Used at the top-level node to indicate the context for the JSON-LD ' +
       'objects used. The context provided in this type is compatible ' +
@@ -36,7 +36,14 @@ function WithContextType(context: Context) {
         ),
       ],
       factory.createIntersectionTypeNode([
-        factory.createTypeReferenceNode('T', /*typeArguments=*/ undefined),
+        // Strip `string` (and any other non-object members) out of T. Every
+        // schema type is a union with `string`, but WithContext is only ever
+        // applied to a top-level object, so a `string & {"@context"}` branch
+        // would be meaningless (see #98).
+        factory.createTypeReferenceNode('Exclude', [
+          factory.createTypeReferenceNode('T', /*typeArguments=*/ undefined),
+          factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+        ]),
         factory.createTypeLiteralNode([context.contextProperty()]),
       ]),
     ),

--- a/packages/schema-dts-gen/test/baselines/category_test.ts
+++ b/packages/schema-dts-gen/test/baselines/category_test.ts
@@ -48,7 +48,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/comments_test.ts
+++ b/packages/schema-dts-gen/test/baselines/comments_test.ts
@@ -68,7 +68,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/data_type_union_test.ts
+++ b/packages/schema-dts-gen/test/baselines/data_type_union_test.ts
@@ -46,7 +46,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/default_ontology_test.ts
+++ b/packages/schema-dts-gen/test/baselines/default_ontology_test.ts
@@ -33,7 +33,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/deprecated_objects_test.ts
+++ b/packages/schema-dts-gen/test/baselines/deprecated_objects_test.ts
@@ -69,7 +69,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/duplicate_comments_test.ts
+++ b/packages/schema-dts-gen/test/baselines/duplicate_comments_test.ts
@@ -50,7 +50,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/enum_skipped_test.ts
+++ b/packages/schema-dts-gen/test/baselines/enum_skipped_test.ts
@@ -46,7 +46,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/inheritance_multiple_test.ts
+++ b/packages/schema-dts-gen/test/baselines/inheritance_multiple_test.ts
@@ -50,7 +50,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/inheritance_one_test.ts
+++ b/packages/schema-dts-gen/test/baselines/inheritance_one_test.ts
@@ -45,7 +45,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/nested_datatype_test.ts
+++ b/packages/schema-dts-gen/test/baselines/nested_datatype_test.ts
@@ -60,7 +60,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/nodeprecated_objects_test.ts
+++ b/packages/schema-dts-gen/test/baselines/nodeprecated_objects_test.ts
@@ -68,7 +68,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/owl_mixed_basic_test.ts
+++ b/packages/schema-dts-gen/test/baselines/owl_mixed_basic_test.ts
@@ -44,7 +44,7 @@ test(`baseline_mixedOWL1_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {
@@ -107,7 +107,7 @@ test(`baseline_mixedOWL2_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {
@@ -175,7 +175,7 @@ test(`baseline_OWLenum_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/property_edge_cases_test.ts
+++ b/packages/schema-dts-gen/test/baselines/property_edge_cases_test.ts
@@ -45,7 +45,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/quantities_test.ts
+++ b/packages/schema-dts-gen/test/baselines/quantities_test.ts
@@ -52,7 +52,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/role_inheritance_test.ts
+++ b/packages/schema-dts-gen/test/baselines/role_inheritance_test.ts
@@ -52,7 +52,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/role_simple_test.ts
+++ b/packages/schema-dts-gen/test/baselines/role_simple_test.ts
@@ -49,7 +49,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/simple_test.ts
+++ b/packages/schema-dts-gen/test/baselines/simple_test.ts
@@ -38,7 +38,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/sorted_enum_test.ts
+++ b/packages/schema-dts-gen/test/baselines/sorted_enum_test.ts
@@ -39,7 +39,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/sorted_props_test.ts
+++ b/packages/schema-dts-gen/test/baselines/sorted_props_test.ts
@@ -47,7 +47,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/sorted_proptypes_test.ts
+++ b/packages/schema-dts-gen/test/baselines/sorted_proptypes_test.ts
@@ -55,7 +55,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/stringlike_http_test.ts
+++ b/packages/schema-dts-gen/test/baselines/stringlike_http_test.ts
@@ -63,7 +63,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/stringlike_https_test.ts
+++ b/packages/schema-dts-gen/test/baselines/stringlike_https_test.ts
@@ -63,7 +63,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_test.ts
+++ b/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_test.ts
@@ -52,7 +52,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_v2_test.ts
+++ b/packages/schema-dts-gen/test/baselines/surgical_procedure_3_4_v2_test.ts
@@ -52,7 +52,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/surgical_procedure_test.ts
+++ b/packages/schema-dts-gen/test/baselines/surgical_procedure_test.ts
@@ -77,7 +77,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/transitive_class_test.ts
+++ b/packages/schema-dts-gen/test/baselines/transitive_class_test.ts
@@ -42,7 +42,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/url_test.ts
+++ b/packages/schema-dts-gen/test/baselines/url_test.ts
@@ -38,7 +38,7 @@ test(`baseline_${basename(import.meta.url)}`, async () => {
 "import type { JsonLdObject, IdReference, MergeLeafTypes } from "schema-dts-lib";
 export type { JsonLdObject, IdReference, MergeLeafTypes };
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
-export type WithContext<T extends JsonLdObject | string> = T & {
+export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {
     "@context": "https://schema.org";
 };
 export interface Graph {

--- a/packages/schema-dts-gen/test/baselines/withcontext_excludes_string_test.ts
+++ b/packages/schema-dts-gen/test/baselines/withcontext_excludes_string_test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Regression test for #98: WithContext<T> must strip the `string`
+ * members out of T. Every schema type is a union with `string` (e.g.
+ * `Organization = OrganizationLeaf | ... | string`), so a bare `T & {...}`
+ * leaves a meaningless `string & {"@context": ...}` branch in the result.
+ * WithContext is always applied to a top-level object, so we exclude `string`.
+ */
+import {basename} from 'path';
+
+import {inlineCli} from '../helpers/main_driver.js';
+
+test(`baseline_${basename(import.meta.url)}`, async () => {
+  const {actual} = await inlineCli(
+    `
+<http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#comment> "Data type: URL." .
+<http://schema.org/URL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+<http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#label> "URL" .
+<http://schema.org/URL> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://schema.org/Text> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/DataType> .
+<http://schema.org/Text> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+      `,
+    ['--ontology', `https://fake.com/${basename(import.meta.url)}.nt`],
+  );
+
+  expect(actual).toContain(
+    'export type WithContext<T extends JsonLdObject | string> = Exclude<T, string> & {',
+  );
+  // The unfixed form leaks a `string & {"@context"}` branch into the result.
+  expect(actual).not.toContain(
+    'export type WithContext<T extends JsonLdObject | string> = T & {',
+  );
+});

--- a/packages/schema-dts/test/withcontext.ts
+++ b/packages/schema-dts/test/withcontext.ts
@@ -21,3 +21,9 @@ const _5: WithContext<Thing> = {
   '@context': 'https://google.com',
   '@type': 'Thing',
 };
+
+// #98: every schema type is a union with `string`, but WithContext is only ever
+// applied to a top-level object. WithContext must strip those `string` members,
+// otherwise the result carries a meaningless `string & {"@context"}` branch.
+type HasNoStringMember<T> = [Extract<T, string>] extends [never] ? true : false;
+const _noStringBranch: HasNoStringMember<WithContext<Thing>> = true;


### PR DESCRIPTION
Every generated schema type is a union that includes `string` (e.g. `Organization = OrganizationLeaf | ... | string`). `WithContext<T>` was emitted as `T & { "@context": ... }`, which left a meaningless `string & { "@context" }` branch in the result — exactly the "cannot intersect string and object" defect reported in #98.

WithContext is only ever applied to a top-level object, so strip the non-object members: emit `Exclude<T, string> & { "@context": ... }`. This matches the maintainer-suggested fix and the factory's own comment.

Adds a generator baseline regression test asserting the emitted shape, a consumer-level assertion that `WithContext<Thing>` has no string member, and regenerates the affected baseline snapshots.

Fixes #98