### PR TITLE
docs: document implementing schema types from a class (leaf types)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,31 @@ const product: WithContext<
 `MergeLeafTypes` expects concrete leaf types such as `ProductLeaf`, not union
 aliases such as `Product`.
 
+### Implementing schema types in a class
+
+Every Schema.org type is exported twice: as a union alias (e.g. `Person`, which
+also spans its subtypes plus an id-reference `string`) and as a concrete "leaf"
+interface (e.g. `PersonLeaf`) describing exactly one `@type`. Because the leaf
+interface is a plain object type, you can `implements` it from a class, which
+the union alias does not allow:
+
+```ts
+import type {PersonLeaf} from 'schema-dts';
+
+class Employee implements PersonLeaf {
+  readonly '@type' = 'Person';
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+```
+
+Reach for the leaf interface (`PersonLeaf`) instead of the union alias
+(`Person`) whenever you need a single, concrete object shape to implement or
+extend.
+
 ### Graphs and IDs
 
 JSON-LD supports `'@graph'` objects that have richer interconnected links

--- a/packages/schema-dts/test/leaf_implements.ts
+++ b/packages/schema-dts/test/leaf_implements.ts
@@ -1,0 +1,27 @@
+import type {PersonLeaf} from '../dist/schema';
+
+// A class can `implements` the concrete leaf interface, which the union alias
+// `Person` (a discriminated union that also includes `string`) does not allow.
+class Employee implements PersonLeaf {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  readonly '@type' = 'Person';
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+const _1: PersonLeaf = new Employee('Ada');
+
+// The leaf interface pins `@type` to a single literal.
+const _2: PersonLeaf = {
+  // @ts-expect-error '@type' must be the "Person" literal.
+  '@type': 'Organization',
+};
+
+// Leaf properties still accept valid Schema.org values.
+const _3: PersonLeaf = {
+  '@type': 'Person',
+  name: 'Ada Lovelace',
+};


### PR DESCRIPTION
## Summary

`schema-dts` v2.0.0 exports a concrete `...Leaf` interface for every Schema.org
type (e.g. `PersonLeaf`) in addition to the union alias (`Person`), but the
README never documents this. This adds a short "Implementing schema types in a
class" section showing that a class can `implements PersonLeaf` — the union
alias cannot be implemented because it is a discriminated union that also
includes an id-reference `string`.

Relates to #28.

## Changes

- README: new "Implementing schema types in a class" section.
- Added `packages/schema-dts/test/leaf_implements.ts` compile-time test asserting
  a class can implement `PersonLeaf`.

## Test plan

- [x] `npm run build`
- [x] `tsc -p packages/schema-dts/test/` passes
- [x] eslint + prettier clean

I have signed / will sign the Google CLA per CONTRIBUTING.md.

Made with [Cursor](https://cursor.com)