### PR TITLE
docs: document reusing a property's type via leaf types

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ const p: WithContext<Person> = {
 };
 ```
 
+### Reusing a property's type
+
+Every Schema.org type is also exported as a concrete "leaf" interface (e.g.
+`OrganizationLeaf`) alongside its union alias (`Organization`). Indexing the
+union alias to grab a single property's type fails, because the alias also
+includes an id-reference `string` that has no properties. Index the leaf
+interface instead:
+
+```ts
+import type {OrganizationLeaf} from 'schema-dts';
+
+// Previously required Exclude<Organization, string>['image'].
+type OrgImage = OrganizationLeaf['image'];
+type OrgLogo = OrganizationLeaf['logo'];
+```
+
 ### Merging multiple concrete types
 
 Some Schema.org objects can legitimately carry multiple concrete `@type` values.

--- a/packages/schema-dts/test/leaf_property.ts
+++ b/packages/schema-dts/test/leaf_property.ts
@@ -1,0 +1,15 @@
+import type {OrganizationLeaf} from '../dist/schema';
+
+// A property's type can be extracted from the concrete leaf interface. Indexing
+// the union alias `Organization` instead would fail, because that alias also
+// includes an id-reference `string` with no properties.
+type OrgImage = OrganizationLeaf['image'];
+type OrgName = OrganizationLeaf['name'];
+
+const _image: OrgImage = 'https://acme.com/logo.png';
+
+const _name: OrgName = 'Acme Corp';
+
+// The extracted type still rejects invalid values.
+// @ts-expect-error image is not a number.
+const _bad: OrgImage = 42;


### PR DESCRIPTION
## Summary

Indexing a union alias like `Organization` to reuse a single property's type
fails, because the alias also includes an id-reference `string` that has no
properties (the workaround was `Exclude<Organization, string>['image']`). Since
v2.0.0, `schema-dts` exports concrete `...Leaf` interfaces, so you can index them
directly: `OrganizationLeaf['image']`. This documents that.

Relates to #50.

## Changes

- README: new "Reusing a property's type" section.
- Added `packages/schema-dts/test/leaf_property.ts` compile-time test asserting
  the extracted property types work.

## Test plan

- [x] `npm run build`
- [x] `tsc -p packages/schema-dts/test/` passes
- [x] eslint + prettier clean

I have signed / will sign the Google CLA per CONTRIBUTING.md.

Made with [Cursor](https://cursor.com)