### PR TITLE
docs: connect MergeLeafTypes to multi-typed entities / array @type

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ const p: WithContext<Person> = {
 
 ### Merging multiple concrete types
 
-Some Schema.org objects can legitimately carry multiple concrete `@type` values.
-For those advanced cases, `schema-dts` exports leaf types alongside the usual
-union aliases, plus a `MergeLeafTypes` helper for combining them:
+A JSON-LD node can be a
+[multi-typed entity](https://schema.org/docs/schemas.html) whose `@type` is an
+array of concrete types, for example
+`'@type': ['Product', 'SoftwareApplication']`. For these cases, `schema-dts`
+exports leaf types alongside the usual union aliases, plus a `MergeLeafTypes`
+helper for combining them:
 
 ```ts
 import type {


### PR DESCRIPTION
## Summary

The "Merging multiple concrete types" README section documents `MergeLeafTypes`
but never names the use cases people actually search for: multi-typed entities
and an array-valued `@type` such as `['Product', 'SoftwareApplication']`. This
adds a short lead-in so those users find the existing helper.

Relates to #179 and #189.

## Changes

- README: clarify the "Merging multiple concrete types" intro (docs-only).

## Test plan

- [x] prettier clean
- [x] Existing `packages/schema-dts/test/mergeleaftypes.ts` already covers behavior.

I have signed / will sign the Google CLA per CONTRIBUTING.md.

Made with [Cursor](https://cursor.com)